### PR TITLE
Feature/lightouse standby mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
  - Renamed Standby to Sleep, just like the steamVR program.
  - Added identify device extension to metadata page.
  - Added standby (motors on, laser off) state extension to metadata page.
+ - Added a setting to use standby instead of sleep by default.
 
 # Version 1.0.1+3 2020-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
  - Added identify device extension to metadata page.
  - Added standby (motors on, laser off) state extension to metadata page.
  - Added a setting to use standby instead of sleep by default.
+ - Added sleep state extension to metadata page.
+ - Added on state extension to metadata page.
 
 # Version 1.0.1+3 2020-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
  - Added a setting to use standby instead of sleep by default.
  - Added sleep state extension to metadata page.
  - Added on state extension to metadata page.
+ - Added a standby option to the unknown state dialog.
 
 # Version 1.0.1+3 2020-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
  - Added the ability to nickname lighthouses.
  - Added settings page.
  - Added channel to metadata page.
+ - Renamed Standby to Sleep, just like the steamVR program.
  - Added identify device extension to metadata page.
+ - Added standby (motors on, laser off) state extension to metadata page.
 
 # Version 1.0.1+3 2020-08-31
 

--- a/lib/bloc.dart
+++ b/lib/bloc.dart
@@ -1,17 +1,24 @@
+import 'package:flutter/foundation.dart';
 import 'package:lighthouse_pm/data/Database.dart';
+import 'package:lighthouse_pm/lighthouseProvider/LighthousePowerState.dart';
+import 'package:moor_flutter/moor_flutter.dart';
+import 'package:rxdart/rxdart.dart';
 
 class LighthousePMBloc {
   final LighthouseDatabase db;
+  final SettingsBloc settings;
 
-  LighthousePMBloc() : db = LighthouseDatabase();
+  LighthousePMBloc(LighthouseDatabase db)
+      : db = db,
+        settings = SettingsBloc(db);
 
   Stream<List<Nickname>> get watchSavedNicknames => db.watchSavedNicknames;
 
-  Stream<Nickname /* ? */> watchNicknameForMacAddress(String macAddress) {
+  Stream<Nickname /* ? */ > watchNicknameForMacAddress(String macAddress) {
     return db.watchNicknameForMacAddress(macAddress);
   }
 
-  Future<int> insertNewNickname(Nickname nickname) =>
+  Future<int> insertNickname(Nickname nickname) =>
       db.insertNewNickname(nickname);
 
   Future deleteNicknames(List<String> macAddresses) =>
@@ -31,5 +38,44 @@ class LighthousePMBloc {
 
   void close() {
     db.close();
+  }
+}
+
+class SettingsBloc {
+  final LighthouseDatabase db;
+
+  SettingsBloc(this.db);
+
+  //IDS
+  static const DEFAULT_SLEEP_STATE_ID = 1;
+
+  Stream<LighthousePowerState> getSleepStateAsStream(
+      {LighthousePowerState defaultValue = LighthousePowerState.SLEEP}) {
+    final dbStream = (db.select(db.simpleSettings)
+          ..where((tbl) => tbl.id.equals(DEFAULT_SLEEP_STATE_ID)))
+        .watch()
+        .map((event) {
+      if (event.length >= 1 && event[0].data != null) {
+        try {
+          final data = int.parse(event[0].data, radix: 10);
+          return LighthousePowerState.fromId(data);
+        } on FormatException {
+          debugPrint('Could not convert data returned to a string');
+        }
+      }
+      return null;
+    });
+    return MergeStream([Stream.value(defaultValue), dbStream]);
+  }
+
+  Future<void> insertSleepState(LighthousePowerState sleepState) {
+    assert(
+        sleepState == LighthousePowerState.SLEEP ||
+            sleepState == LighthousePowerState.STANDBY,
+        'The new sleep state cannot be ${sleepState.text.toUpperCase()}');
+    return db.into(db.simpleSettings).insert(
+        SimpleSetting(
+            id: DEFAULT_SLEEP_STATE_ID, data: sleepState.id.toString()),
+        mode: InsertMode.insertOrReplace);
   }
 }

--- a/lib/data/Database.dart
+++ b/lib/data/Database.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:lighthouse_pm/data/tables/SimpleSettingsTable.dart';
 import 'package:moor/ffi.dart';
 import 'package:moor/moor.dart';
 import 'package:path/path.dart' as p;
@@ -18,8 +19,9 @@ class NicknamesLastSeenJoin {
   final DateTime /* ? */ lastSeen;
 }
 
-// This file required generated files. Use `flutter packages pub run build_runner
-// build` or `flutter packages pub run build_runner watch` to generate these files.
+// This file required generated files.
+// Use `flutter packages pub run build_runner build`
+// or `flutter packages pub run build_runner watch` to generate these files.
 
 LazyDatabase _openConnection() {
   // the LazyDatabase util lets us find the right location for the file async.
@@ -32,7 +34,7 @@ LazyDatabase _openConnection() {
   });
 }
 
-@UseMoor(tables: [Nicknames, LastSeenDevices])
+@UseMoor(tables: [Nicknames, LastSeenDevices, SimpleSettings])
 class LighthouseDatabase extends _$LighthouseDatabase {
   LighthouseDatabase() : super(_openConnection());
 

--- a/lib/data/local/MainPageSettings.dart
+++ b/lib/data/local/MainPageSettings.dart
@@ -1,0 +1,29 @@
+import 'package:lighthouse_pm/bloc.dart';
+import 'package:lighthouse_pm/lighthouseProvider/LighthousePowerState.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:tuple/tuple.dart';
+
+class MainPageSettings {
+  const MainPageSettings(this.sleepState);
+
+  final LighthousePowerState sleepState;
+
+  static const DEFAULT_MAIN_PAGE_SETTINGS = MainPageSettings(LighthousePowerState.SLEEP);
+  
+  static Stream<MainPageSettings> mainPageSettingsStream(LighthousePMBloc bloc) {
+    LighthousePowerState sleepState = DEFAULT_MAIN_PAGE_SETTINGS.sleepState;
+    return MergeStream<Tuple2<int, dynamic>>([
+      bloc.settings
+          .getSleepStateAsStream()
+          .map((state) => Tuple2(SettingsBloc.DEFAULT_SLEEP_STATE_ID, state))
+    ]).map((event) {
+      switch (event.item1) {
+        case SettingsBloc.DEFAULT_SLEEP_STATE_ID:
+          if (event.item2 != null) {
+            sleepState = event.item2 as LighthousePowerState;
+          }
+      }
+      return MainPageSettings(sleepState);
+    });
+  }
+}

--- a/lib/data/tables/SimpleSettingsTable.dart
+++ b/lib/data/tables/SimpleSettingsTable.dart
@@ -1,0 +1,9 @@
+import 'package:moor_flutter/moor_flutter.dart';
+
+class SimpleSettings extends Table {
+  IntColumn get id => integer()();
+  TextColumn get data => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/lighthouseProvider/LighthousePowerState.dart
+++ b/lib/lighthouseProvider/LighthousePowerState.dart
@@ -8,4 +8,5 @@ class LighthousePowerState {
   static const ON = const LighthousePowerState._internal('On');
   static const UNKNOWN = const LighthousePowerState._internal('Unknown');
   static const BOOTING = const LighthousePowerState._internal('Booting');
+  static const STANDBY = const LighthousePowerState._internal('Standby');
 }

--- a/lib/lighthouseProvider/LighthousePowerState.dart
+++ b/lib/lighthouseProvider/LighthousePowerState.dart
@@ -1,12 +1,36 @@
 /// A enum that describes the current power state of a lighthouse beacon.
 class LighthousePowerState {
   final String text;
+  ///
+  /// This is for storing into the data base. These should all be unique and
+  /// not change between versions!
+  final int id;
 
-  const LighthousePowerState._internal(this.text);
+  const LighthousePowerState._internal(this.text, this.id);
 
-  static const SLEEP = const LighthousePowerState._internal('Sleep');
-  static const ON = const LighthousePowerState._internal('On');
-  static const UNKNOWN = const LighthousePowerState._internal('Unknown');
-  static const BOOTING = const LighthousePowerState._internal('Booting');
-  static const STANDBY = const LighthousePowerState._internal('Standby');
+  static const SLEEP = const LighthousePowerState._internal('Sleep', 0);
+  static const ON = const LighthousePowerState._internal('On', 1);
+  static const UNKNOWN = const LighthousePowerState._internal('Unknown', 2);
+  static const BOOTING = const LighthousePowerState._internal('Booting', 3);
+  static const STANDBY = const LighthousePowerState._internal('Standby', 4);
+
+
+  static LighthousePowerState fromId(int id) {
+    switch(id) {
+      case 0:
+        return SLEEP;
+      case 1:
+        return ON;
+      case 2:
+        return UNKNOWN;
+      case 3:
+        return BOOTING;
+      case 4:
+        return STANDBY;
+      default:
+        assert(false, 'Unknown id provided!');
+        return null;
+    }
+  }
+
 }

--- a/lib/lighthouseProvider/deviceExtensions/DeviceExtension.dart
+++ b/lib/lighthouseProvider/deviceExtensions/DeviceExtension.dart
@@ -4,8 +4,8 @@ typedef FutureCallback = Future<void> Function();
 typedef StreamEnabledFunction = Stream<bool> Function();
 
 //A single device extension to add extra functionality to a device.
-abstract class DeviceExtensions {
-  DeviceExtensions(
+abstract class DeviceExtension {
+  DeviceExtension(
       {@required this.toolTip,
       @required this.icon,
       @required this.onTap,

--- a/lib/lighthouseProvider/deviceExtensions/DeviceWithExtensions.dart
+++ b/lib/lighthouseProvider/deviceExtensions/DeviceWithExtensions.dart
@@ -1,6 +1,6 @@
-import './DeviceExtensions.dart';
+import './DeviceExtension.dart';
 
 /// An interface for devices that have extra function extensions.
 abstract class DeviceWithExtensions {
-  final Set<DeviceExtensions> deviceExtensions = Set();
+  final Set<DeviceExtension> deviceExtensions = Set();
 }

--- a/lib/lighthouseProvider/deviceExtensions/IdentifyDeviceExtension.dart
+++ b/lib/lighthouseProvider/deviceExtensions/IdentifyDeviceExtension.dart
@@ -1,10 +1,10 @@
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:rxdart/rxdart.dart';
 
-import 'DeviceExtensions.dart';
+import 'DeviceExtension.dart';
 
 /// A device extension that allow the device to be identified.
-class IdentifyDeviceExtension extends DeviceExtensions {
+class IdentifyDeviceExtension extends DeviceExtension {
   IdentifyDeviceExtension({FutureCallback onTap})
       : super(
             onTap: onTap,

--- a/lib/lighthouseProvider/deviceExtensions/OnExtension.dart
+++ b/lib/lighthouseProvider/deviceExtensions/OnExtension.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../LighthousePowerState.dart';
+import 'StateExtension.dart';
+
+///
+/// An extension to allow a device to turn on
+///
+class OnExtension extends StateExtension {
+  OnExtension(
+      {@required ChangeStateFunction changeState,
+      @required Stream<LighthousePowerState> powerStateStream})
+      : super(
+            toolTip: "On",
+            icon:
+                Icon(Icons.power_settings_new, size: 24, color: Colors.green),
+            changeState: changeState,
+            powerStateStream: powerStateStream,
+            toState: LighthousePowerState.ON);
+}
+

--- a/lib/lighthouseProvider/deviceExtensions/SleepExtension.dart
+++ b/lib/lighthouseProvider/deviceExtensions/SleepExtension.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../LighthousePowerState.dart';
+import 'StateExtension.dart';
+
+///
+/// An extension to allow a device to go into sleep mode
+///
+class SleepExtension extends StateExtension {
+  SleepExtension(
+      {@required ChangeStateFunction changeState,
+      @required Stream<LighthousePowerState> powerStateStream})
+      : super(
+            toolTip: "Sleep",
+            icon:
+                Icon(Icons.power_settings_new, size: 24, color: Colors.blue),
+            changeState: changeState,
+            powerStateStream: powerStateStream,
+            toState: LighthousePowerState.SLEEP);
+}
+

--- a/lib/lighthouseProvider/deviceExtensions/StandbyExtension.dart
+++ b/lib/lighthouseProvider/deviceExtensions/StandbyExtension.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'DeviceWithExtensions.dart';
 
+import '../LighthouseDevice.dart';
 import '../LighthousePowerState.dart';
 import 'StateExtension.dart';
 
+///
+/// An extension to allow a device to go into standby mode
+///
 class StandbyExtension extends StateExtension {
   StandbyExtension(
       {@required ChangeStateFunction changeState,
@@ -15,4 +20,19 @@ class StandbyExtension extends StateExtension {
             changeState: changeState,
             powerStateStream: powerStateStream,
             toState: LighthousePowerState.STANDBY);
+}
+
+extension StandbyExtensionExtensions on LighthouseDevice {
+  bool get hasStandbyExtension {
+    if (!(this is DeviceWithExtensions)) {
+      return false;
+    }
+    final device = this as DeviceWithExtensions;
+    for (final extension in device.deviceExtensions) {
+      if (extension is StandbyExtension) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/lib/lighthouseProvider/deviceExtensions/StandbyExtension.dart
+++ b/lib/lighthouseProvider/deviceExtensions/StandbyExtension.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../LighthousePowerState.dart';
+import 'StateExtension.dart';
+
+class StandbyExtension extends StateExtension {
+  StandbyExtension(
+      {@required ChangeStateFunction changeState,
+      @required Stream<LighthousePowerState> powerStateStream})
+      : super(
+            toolTip: "Standby",
+            icon:
+                Icon(Icons.power_settings_new, size: 24, color: Colors.orange),
+            changeState: changeState,
+            powerStateStream: powerStateStream,
+            toState: LighthousePowerState.STANDBY);
+}

--- a/lib/lighthouseProvider/deviceExtensions/StandbyExtension.dart
+++ b/lib/lighthouseProvider/deviceExtensions/StandbyExtension.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'DeviceWithExtensions.dart';
 
 import '../LighthouseDevice.dart';
 import '../LighthousePowerState.dart';
+import 'DeviceWithExtensions.dart';
 import 'StateExtension.dart';
 
 ///
@@ -28,11 +28,9 @@ extension StandbyExtensionExtensions on LighthouseDevice {
       return false;
     }
     final device = this as DeviceWithExtensions;
-    for (final extension in device.deviceExtensions) {
-      if (extension is StandbyExtension) {
-        return true;
-      }
-    }
-    return false;
+    return device.deviceExtensions.firstWhere(
+            (element) => element is StandbyExtension,
+            orElse: () => null) !=
+        null;
   }
 }

--- a/lib/lighthouseProvider/deviceExtensions/StateExtension.dart
+++ b/lib/lighthouseProvider/deviceExtensions/StateExtension.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:lighthouse_pm/lighthouseProvider/LighthousePowerState.dart';
+import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/DeviceExtension.dart';
+
+typedef ChangeStateFunction = Future<void> Function(
+    LighthousePowerState newState);
+
+///
+/// An extension for some extra states a device might have.
+///
+abstract class StateExtension extends DeviceExtension {
+  StateExtension(
+      {@required String toolTip,
+      @required Widget icon,
+      @required ChangeStateFunction changeState,
+      @required this.powerStateStream,
+      @required this.toState})
+      : super(toolTip: toolTip, icon: icon, onTap: () => changeState(toState)) {
+    super.streamEnabledFunction = _enabledStream;
+    assert(toState != LighthousePowerState.UNKNOWN && toState != LighthousePowerState.BOOTING, 'Cannot have a StateExtension that sets the power state to ${toState.text.toUpperCase()}');
+  }
+
+  final Stream<LighthousePowerState> powerStateStream;
+  final LighthousePowerState toState;
+
+  Stream<bool> _enabledStream() {
+    return powerStateStream.map((state) {
+      return state != LighthousePowerState.BOOTING && state != toState;
+    });
+  }
+}

--- a/lib/lighthouseProvider/deviceProviders/BLEDeviceProvider.dart
+++ b/lib/lighthouseProvider/deviceProviders/BLEDeviceProvider.dart
@@ -24,10 +24,14 @@ abstract class BLEDeviceProvider extends DeviceProvider<BluetoothDevice> {
     try {
       final valid = await bleDevice.isValid();
       this._bleDevicesDiscovering.remove(bleDevice);
+      if (valid){
+        bleDevice.afterIsValid();
+      }
       return valid ? bleDevice : null;
     } catch (e, s) {
       debugPrint('$e');
       debugPrint('$s');
+      bleDevice.disconnect();
       return null;
     }
   }

--- a/lib/lighthouseProvider/devices/BLEDevice.dart
+++ b/lib/lighthouseProvider/devices/BLEDevice.dart
@@ -33,6 +33,11 @@ abstract class BLEDevice extends LighthouseDevice {
       LHDeviceIdentifier.fromFlutterBlue(device.id);
 
   ///
+  /// Fired after the isValid method has returned true.
+  ///
+  void afterIsValid();
+
+  ///
   /// If this is a valid device of the specified type.
   ///
   Future<bool> isValid();

--- a/lib/lighthouseProvider/devices/LighthouseV2Device.dart
+++ b/lib/lighthouseProvider/devices/LighthouseV2Device.dart
@@ -86,9 +86,12 @@ class LighthouseV2Device extends BLEDevice implements DeviceWithExtensions {
     switch (byte) {
       case 0x00:
         return LighthousePowerState.SLEEP;
+      case 0x02:
+        return LighthousePowerState.STANDBY;
       case 0x0b:
         return LighthousePowerState.ON;
       case 0x01:
+      case 0x08:
       case 0x09:
         return LighthousePowerState.BOOTING;
       default:
@@ -208,6 +211,9 @@ class LighthouseV2Device extends BLEDevice implements DeviceWithExtensions {
           break;
         case LighthousePowerState.SLEEP:
           await this._characteristic.write([0x00], withoutResponse: true);
+          break;
+        case LighthousePowerState.STANDBY:
+          await this._characteristic.write([0x02], withoutResponse: true);
           break;
       }
     }

--- a/lib/lighthouseProvider/devices/LighthouseV2Device.dart
+++ b/lib/lighthouseProvider/devices/LighthouseV2Device.dart
@@ -8,6 +8,8 @@ import 'package:lighthouse_pm/lighthouseProvider/ble/Guid.dart';
 import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/DeviceExtension.dart';
 import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/DeviceWithExtensions.dart';
 import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/IdentifyDeviceExtension.dart';
+import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/OnExtension.dart';
+import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/SleepExtension.dart';
 import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/StandbyExtension.dart';
 import 'package:lighthouse_pm/lighthouseProvider/devices/BLEDevice.dart';
 import 'package:lighthouse_pm/lighthouseProvider/helpers/FlutterBlueExtensions.dart';
@@ -24,7 +26,7 @@ const String _IDENTIFY_CHARACTERISTIC = '00008421-1212-EFDE-1523-785FEABCD124';
 
 class LighthouseV2Device extends BLEDevice implements DeviceWithExtensions {
   LighthouseV2Device(BluetoothDevice device) : super(device) {
-    // Add a part of the [DeviceExtenion]s the rest are added after
+    // Add a part of the [DeviceExtenion]s the rest are added after [afterIsValid].
     deviceExtensions.add(IdentifyDeviceExtension(onTap: identify));
   }
 
@@ -197,6 +199,10 @@ class LighthouseV2Device extends BLEDevice implements DeviceWithExtensions {
   void afterIsValid() {
     // Add the extra extensions that need a valid connection to work.
     deviceExtensions.add(StandbyExtension(
+        changeState: changeState, powerStateStream: powerStateEnum));
+    deviceExtensions.add(SleepExtension(
+        changeState: changeState, powerStateStream: powerStateEnum));
+    deviceExtensions.add(OnExtension(
         changeState: changeState, powerStateStream: powerStateEnum));
   }
 

--- a/lib/lighthouseProvider/devices/LighthouseV2Device.dart
+++ b/lib/lighthouseProvider/devices/LighthouseV2Device.dart
@@ -5,14 +5,15 @@ import 'package:flutter_blue/flutter_blue.dart';
 import 'package:lighthouse_pm/lighthouseProvider/LighthousePowerState.dart';
 import 'package:lighthouse_pm/lighthouseProvider/ble/DefaultCharacteristics.dart';
 import 'package:lighthouse_pm/lighthouseProvider/ble/Guid.dart';
-import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/DeviceExtensions.dart';
+import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/DeviceExtension.dart';
 import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/DeviceWithExtensions.dart';
 import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/IdentifyDeviceExtension.dart';
+import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/StandbyExtension.dart';
 import 'package:lighthouse_pm/lighthouseProvider/devices/BLEDevice.dart';
 import 'package:lighthouse_pm/lighthouseProvider/helpers/FlutterBlueExtensions.dart';
 
 ///The bluetooth service that handles the power state of the device.
-// final Guid _POWER_SERVICE = Guid('00001523-1212-efde-1523-785feabcd124');
+// final String _POWER_SERVICE = '00001523-1212-efde-1523-785feabcd124';
 
 ///The characteristic that handles the power state of the device.
 const String _POWER_CHARACTERISTIC = '00001525-1212-efde-1523-785feabcd124';
@@ -23,11 +24,12 @@ const String _IDENTIFY_CHARACTERISTIC = '00008421-1212-EFDE-1523-785FEABCD124';
 
 class LighthouseV2Device extends BLEDevice implements DeviceWithExtensions {
   LighthouseV2Device(BluetoothDevice device) : super(device) {
+    // Add a part of the [DeviceExtenion]s the rest are added after
     deviceExtensions.add(IdentifyDeviceExtension(onTap: identify));
   }
 
   @override
-  final Set<DeviceExtensions> deviceExtensions = Set();
+  final Set<DeviceExtension> deviceExtensions = Set();
   BluetoothCharacteristic /* ? */ _characteristic;
   BluetoothCharacteristic /* ? */ _identifyCharacteristic;
   String /* ? */ _firmwareVersion;
@@ -190,6 +192,12 @@ class LighthouseV2Device extends BLEDevice implements DeviceWithExtensions {
     }
     await disconnect();
     return false;
+  }
+
+  void afterIsValid() {
+    // Add the extra extensions that need a valid connection to work.
+    deviceExtensions.add(StandbyExtension(
+        changeState: changeState, powerStateStream: powerStateEnum));
   }
 
   @override

--- a/lib/lighthouseProvider/widgets/LighthouseMetadataPage.dart
+++ b/lib/lighthouseProvider/widgets/LighthouseMetadataPage.dart
@@ -37,7 +37,7 @@ class LighthouseMetadataState extends State<LighthouseMetadataPage> {
       if (newNickname.nickname == null) {
         await _blocWithoutListen.deleteNicknames([newNickname.macAddress]);
       } else {
-        await _blocWithoutListen.insertNewNickname(newNickname);
+        await _blocWithoutListen.insertNickname(newNickname);
       }
     }
   }

--- a/lib/lighthouseProvider/widgets/LighthouseMetadataPage.dart
+++ b/lib/lighthouseProvider/widgets/LighthouseMetadataPage.dart
@@ -171,7 +171,7 @@ class _ExtraActionsWidget extends StatelessWidget {
                               elevation: 2.0,
                               fillColor: (snapshot.hasData && snapshot.data)
                                   ? Colors.white
-                                  : Colors.white30,
+                                  : Colors.white54,
                               padding: const EdgeInsets.all(2.0),
                               shape: CircleBorder(),
                               child: extensions[index].icon,

--- a/lib/lighthouseProvider/widgets/LighthouseWidget.dart
+++ b/lib/lighthouseProvider/widgets/LighthouseWidget.dart
@@ -106,6 +106,11 @@ class LighthouseWidget extends StatelessWidget {
                                 switch (await UnknownStateAlertWidget
                                     .showCustomDialog(
                                         context, lighthouseDevice, data)) {
+                                  case LighthousePowerState.STANDBY:
+                                    await this
+                                        .lighthouseDevice
+                                        .changeState(LighthousePowerState.STANDBY);
+                                    break;
                                   case LighthousePowerState.ON:
                                     continue powerOn;
                                   case LighthousePowerState.SLEEP:

--- a/lib/lighthouseProvider/widgets/LighthouseWidget.dart
+++ b/lib/lighthouseProvider/widgets/LighthouseWidget.dart
@@ -4,19 +4,30 @@ import 'package:lighthouse_pm/lighthouseProvider/widgets/UnknownStateAlertWidget
 
 import '../LighthouseDevice.dart';
 import '../LighthousePowerState.dart';
+import '../deviceExtensions/StandbyExtension.dart';
 
 typedef LighthousePowerState _ToPowerState(int byte);
 
 /// A widget for showing a [LighthouseDevice] in a list.
 class LighthouseWidget extends StatelessWidget {
   LighthouseWidget(this.lighthouseDevice,
-      {this.onLongPress, this.selected, this.nickname, Key key})
-      : super(key: key);
+      {this.onLongPress,
+      this.selected,
+      this.nickname,
+      this.sleepState = LighthousePowerState.SLEEP,
+      Key key})
+      : super(key: key) {
+    assert(
+        sleepState == LighthousePowerState.SLEEP ||
+            sleepState == LighthousePowerState.STANDBY,
+        'The sleep state may not be ${sleepState.text.toUpperCase()}');
+  }
 
   final LighthouseDevice lighthouseDevice;
   final GestureLongPressCallback onLongPress;
   final bool selected;
   final String /* ? */ nickname;
+  final LighthousePowerState sleepState;
 
   @override
   Widget build(BuildContext context) {
@@ -103,9 +114,17 @@ class LighthouseWidget extends StatelessWidget {
                                 break;
                               powerOff:
                               case LighthousePowerState.ON:
-                                await this
-                                    .lighthouseDevice
-                                    .changeState(LighthousePowerState.SLEEP);
+                                if (lighthouseDevice.hasStandbyExtension) {
+                                  await this
+                                      .lighthouseDevice
+                                      .changeState(this.sleepState);
+                                } else {
+                                  debugPrint(
+                                      'The device doesn\'t support STANDBY so SLEEP will always be used.');
+                                  await this
+                                      .lighthouseDevice
+                                      .changeState(LighthousePowerState.SLEEP);
+                                }
                                 break;
                               powerOn:
                               case LighthousePowerState.STANDBY:

--- a/lib/lighthouseProvider/widgets/LighthouseWidget.dart
+++ b/lib/lighthouseProvider/widgets/LighthouseWidget.dart
@@ -108,6 +108,7 @@ class LighthouseWidget extends StatelessWidget {
                                     .changeState(LighthousePowerState.SLEEP);
                                 break;
                               powerOn:
+                              case LighthousePowerState.STANDBY:
                               case LighthousePowerState.SLEEP:
                                 await this
                                     .lighthouseDevice
@@ -170,8 +171,11 @@ class _LHItemButtonWidget extends StatelessWidget {
       case LighthousePowerState.SLEEP:
         color = Colors.blue;
         break;
-      case LighthousePowerState.BOOTING:
+      case LighthousePowerState.STANDBY:
         color = Colors.orange;
+        break;
+      case LighthousePowerState.BOOTING:
+        color = Colors.yellow;
         break;
     }
     return Padding(

--- a/lib/lighthouseProvider/widgets/UnknownStateAlertWidget.dart
+++ b/lib/lighthouseProvider/widgets/UnknownStateAlertWidget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:lighthouse_pm/lighthouseProvider/LighthouseDevice.dart';
 import 'package:lighthouse_pm/lighthouseProvider/LighthousePowerState.dart';
 import 'package:lighthouse_pm/lighthouseProvider/helpers/CustomLongPressGestureRecognizer.dart';
+import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/StandbyExtension.dart';
 import 'package:package_info/package_info.dart';
 import 'package:toast/toast.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -22,6 +23,38 @@ class UnknownStateAlertWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+
+    final actions = <Widget>[
+      SimpleDialogOption(
+        child: Text("On"),
+        onPressed: () {
+          Navigator.pop(context, LighthousePowerState.ON);
+        },
+      ),
+      SimpleDialogOption(
+        child: Text("Sleep"),
+        onPressed: () {
+          Navigator.pop(context, LighthousePowerState.SLEEP);
+        },
+      ),
+      SimpleDialogOption(
+        child: Text("Cancel"),
+        onPressed: () {
+          Navigator.pop(context, null);
+        },
+      ),
+    ];
+
+    // Add standby, but only if it's supported
+    if (device.hasStandbyExtension) {
+      actions.insert(1, SimpleDialogOption(
+        child: Text("Standby"),
+        onPressed: () {
+          Navigator.pop(context, LighthousePowerState.STANDBY);
+        },
+      ));
+    }
+
     return AlertDialog(
         title: Text('Unknown state'),
         content: RichText(
@@ -43,26 +76,7 @@ class UnknownStateAlertWidget extends StatelessWidget {
             )
           ]),
         ),
-        actions: <Widget>[
-          SimpleDialogOption(
-            child: Text("Start device"),
-            onPressed: () {
-              Navigator.pop(context, LighthousePowerState.ON);
-            },
-          ),
-          SimpleDialogOption(
-            child: Text("Shutdown device"),
-            onPressed: () {
-              Navigator.pop(context, LighthousePowerState.SLEEP);
-            },
-          ),
-          SimpleDialogOption(
-            child: Text("Cancel"),
-            onPressed: () {
-              Navigator.pop(context, null);
-            },
-          ),
-        ]);
+        actions: actions);
   }
 
   static Future<LighthousePowerState /* ? */ > showCustomDialog(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl_standalone.dart';
+import 'package:lighthouse_pm/data/Database.dart';
 import 'package:lighthouse_pm/lighthouseProvider/LighthouseProvider.dart';
 import 'package:lighthouse_pm/lighthouseProvider/deviceProviders/LighthouseV2DeviceProvider.dart';
 import 'package:lighthouse_pm/pages/MainPage.dart';
@@ -24,7 +25,7 @@ class MainApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Provider<LighthousePMBloc>(
-      create: (_) => LighthousePMBloc(),
+      create: (_) => LighthousePMBloc(LighthouseDatabase()),
       dispose: (_, bloc) => bloc.close(),
       child: MaterialApp(
           debugShowCheckedModeBanner: true,

--- a/lib/pages/SettingsPage.dart
+++ b/lib/pages/SettingsPage.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:lighthouse_pm/bloc.dart';
+import 'package:lighthouse_pm/lighthouseProvider/LighthousePowerState.dart';
 import 'package:lighthouse_pm/pages/settings/SettingsNicknamesPage.dart';
 import 'package:lighthouse_pm/widgets/ClearLastSeenAlertWidget.dart';
 import 'package:package_info/package_info.dart';
@@ -59,6 +60,25 @@ class SettingsPage extends StatelessWidget {
                   }
                 }),
             Divider(),
+            StreamBuilder<LighthousePowerState>(
+              stream: _bloc(context).settings.getSleepStateAsStream(),
+              builder: (BuildContext c,
+                  AsyncSnapshot<LighthousePowerState> snapshot) {
+                final state = snapshot.hasData &&
+                    snapshot.data == LighthousePowerState.STANDBY;
+                return SwitchListTile(
+                  title: Text('Use STANDBY instead of SLEEP'),
+                  value: state,
+                  onChanged: (value) {
+                    _bloc(context).settings.insertSleepState(value
+                        ? LighthousePowerState.STANDBY
+                        : LighthousePowerState.SLEEP);
+                  },
+                );
+              },
+            ),
+            Divider(),
+            // About goes here!
             ListTile(
               title: Text('About',
                   style: Theme.of(context)

--- a/lib/pages/settings/SettingsNicknamesPage.dart
+++ b/lib/pages/settings/SettingsNicknamesPage.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lighthouse_pm/bloc.dart';
@@ -43,7 +44,7 @@ class _NicknamesPage extends State<SettingsNicknamesPage> {
   }
 
   Future _updateItem(Nickname nickname) {
-    return blocWithoutListen.insertNewNickname(nickname);
+    return blocWithoutListen.insertNickname(nickname);
   }
 
   @override
@@ -215,40 +216,41 @@ class _EmptyNicknameState extends State<_EmptyNicknamePage> {
 
   @override
   Widget build(BuildContext context) {
+    final Widget blockIcon = kReleaseMode ? Icon(Icons.block, size: 120.0) : GestureDetector(
+      onTap: () {
+        if (tapCounter < _TAP_TOP) {
+          tapCounter++;
+        }
+        if (tapCounter < _TAP_TOP && tapCounter > _TAP_TOP - 3) {
+          Toast.show(
+              'Just ${_TAP_TOP - tapCounter} left until a fake nickname is created',
+              context);
+        }
+        if (tapCounter == _TAP_TOP) {
+          bloc.insertNickname(Nickname(
+              macAddress: "FF:FF:FF:FF:FF:FF",
+              nickname: "This is a test nickname1"));
+          bloc.insertNickname(Nickname(
+              macAddress: "FF:FF:FF:FF:FF:FE",
+              nickname: "This is a test nickname2"));
+          bloc.insertNickname(Nickname(
+              macAddress: "FF:FF:FF:FF:FF:FD",
+              nickname: "This is a test nickname3"));
+          bloc.insertNickname(Nickname(
+              macAddress: "FF:FF:FF:FF:FF:FC",
+              nickname: "This is a test nickname4"));
+          Toast.show('Fake nickname created!', context,
+              duration: Toast.LENGTH_LONG);
+          tapCounter++;
+        }
+      },
+      child: Icon(Icons.block, size: 120.0) ,
+    );
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          GestureDetector(
-            onTap: () {
-              if (tapCounter < _TAP_TOP) {
-                tapCounter++;
-              }
-              if (tapCounter < _TAP_TOP && tapCounter > _TAP_TOP - 3) {
-                Toast.show(
-                    'Just ${_TAP_TOP - tapCounter} left until a fake nickname is created',
-                    context);
-              }
-              if (tapCounter == _TAP_TOP) {
-                bloc.insertNewNickname(Nickname(
-                    macAddress: "FF:FF:FF:FF:FF:FF",
-                    nickname: "This is a test nickname1"));
-                bloc.insertNewNickname(Nickname(
-                    macAddress: "FF:FF:FF:FF:FF:FE",
-                    nickname: "This is a test nickname2"));
-                bloc.insertNewNickname(Nickname(
-                    macAddress: "FF:FF:FF:FF:FF:FD",
-                    nickname: "This is a test nickname3"));
-                bloc.insertNewNickname(Nickname(
-                    macAddress: "FF:FF:FF:FF:FF:FC",
-                    nickname: "This is a test nickname4"));
-                Toast.show('Fake nickname created!', context,
-                    duration: Toast.LENGTH_LONG);
-                tapCounter++;
-              }
-            },
-            child: Icon(Icons.block, size: 120.0),
-          ),
+          blockIcon,
           Text(
             'No nicknames given (yet).',
             style: Theme.of(context).textTheme.headline6,


### PR DESCRIPTION
 - Added standby (motors on, laser off) state extension to metadata page.
 - Added a setting to use standby instead of sleep by default.
 - Added sleep state extension to metadata page.
 - Added on state extension to metadata page.
 - Added a standby option to the unknown state dialog.

Closes #50 