### PR TITLE
Fixed urls not working on Android 11

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,8 +8,6 @@
     <uses-feature
         android:name="android.hardware.bluetooth_le"
         android:required="true" />
-    <!--Fix for not being able to check canLaunch on Android 30 and up-->
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:allowBackup="true"

--- a/lib/lighthouseProvider/widgets/UnknownStateAlertWidget.dart
+++ b/lib/lighthouseProvider/widgets/UnknownStateAlertWidget.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:lighthouse_pm/lighthouseProvider/LighthouseDevice.dart';
 import 'package:lighthouse_pm/lighthouseProvider/LighthousePowerState.dart';
-import 'package:lighthouse_pm/lighthouseProvider/helpers/CustomLongPressGestureRecognizer.dart';
 import 'package:lighthouse_pm/lighthouseProvider/deviceExtensions/StandbyExtension.dart';
+import 'package:lighthouse_pm/lighthouseProvider/helpers/CustomLongPressGestureRecognizer.dart';
 import 'package:package_info/package_info.dart';
 import 'package:toast/toast.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -23,7 +23,6 @@ class UnknownStateAlertWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
     final actions = <Widget>[
       SimpleDialogOption(
         child: Text("On"),
@@ -47,12 +46,14 @@ class UnknownStateAlertWidget extends StatelessWidget {
 
     // Add standby, but only if it's supported
     if (device.hasStandbyExtension) {
-      actions.insert(1, SimpleDialogOption(
-        child: Text("Standby"),
-        onPressed: () {
-          Navigator.pop(context, LighthousePowerState.STANDBY);
-        },
-      ));
+      actions.insert(
+          1,
+          SimpleDialogOption(
+            child: Text("Standby"),
+            onPressed: () {
+              Navigator.pop(context, LighthousePowerState.STANDBY);
+            },
+          ));
     }
 
     return AlertDialog(
@@ -195,9 +196,7 @@ class UnknownStateHelpOutAlertWidget extends StatelessWidget {
         SimpleDialogOption(
           child: Text("Open issue"),
           onPressed: () async {
-            if (await canLaunch(_GITHUB_ISSUE_URL)) {
-              await launch(_GITHUB_ISSUE_URL);
-            }
+            await launch(_GITHUB_ISSUE_URL);
           },
         ),
         SimpleDialogOption(

--- a/lib/pages/SettingsPage.dart
+++ b/lib/pages/SettingsPage.dart
@@ -200,9 +200,7 @@ class SettingsPage extends StatelessWidget {
                     height: 24,
                   ),
                   onTap: () async {
-                    if (await canLaunch(_GITHUB_URL)) {
-                      await launch(_GITHUB_URL);
-                    }
+                    await launch(_GITHUB_URL);
                   },
                 ),
                 Divider(),


### PR DESCRIPTION
Removed can launch since `http` and `https` uri's are always allowed to be launched.

url_launcher uses a package query to check if there are apps that can launch the `uri`. But since `http` and `https` uri's are (almost) always able to be opened, this has become useless. There also isn't  a query that I could find for `https` and/ or `http` support in the manifest.

Removed `<uses-permission android:name"android.permission.QUERY_ALL_PACKAGES"/>` from the Android manifest since the app didn't match the criteria on https://developer.android.com/training/basics/intents/package-visibility#all-apps with the risk of the Google Play store rejecting the update if left in.

closes  #53.