### PR TITLE
Added support for F-droid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 
-# Version 1.1.2+7 RC
+# Version 1.1.2+7 23-02-2021
 
-- (iOS) Fixed automatic detection of "System Theme" availability.
-- Open metadata page by tapping on lighthouse instead of holding power button (holding the power button still works).
+ - (iOS) Fixed automatic detection of "System Theme" availability.
+ - Open metadata page by tapping on lighthouse instead of holding power button (holding the power button still works).
+ - Added support for F-droid.
+ - Updated dependencies.
 
 # Version 1.1.1+6 02-10-2020
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.4.30'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.1.1+6
+version: 1.1.2+7
 
 environment:
   sdk: ">=2.10.3 <3.0.0"


### PR DESCRIPTION
You can no longer build the code at version 1.1.1+6 because Flutter has been updated and the Build_runner version defined in that version doesn't work anymore. Because of this we need to make a new release.

See #88 