### PR TITLE
Added option for changing the update interval.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - (Debug only )Added database test for debugging.
  - Standardized dialog button order (sorry for the inconvenience).
  - Added the ability to group devices.
+ - Added option for changing update interval.
 
 # Version 1.1.2+7 23-02-2021
 

--- a/android/app/src/main/kotlin/com/jeroen1602/lighthouse_pm/Shortcut.kt
+++ b/android/app/src/main/kotlin/com/jeroen1602/lighthouse_pm/Shortcut.kt
@@ -1,7 +1,6 @@
 package com.jeroen1602.lighthouse_pm
 
 import android.annotation.SuppressLint
-import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ShortcutInfo
@@ -18,7 +17,6 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.security.MessageDigest
-import kotlin.math.floor
 import kotlin.math.pow
 import kotlin.math.roundToInt
 

--- a/lib/data/dao/SettingsDao.dart
+++ b/lib/data/dao/SettingsDao.dart
@@ -17,7 +17,7 @@ class SettingsDao extends DatabaseAccessor<LighthouseDatabase>
   SettingsDao(LighthouseDatabase attachedDatabase) : super(attachedDatabase);
 
   static const SCAN_DURATION_VALUES = const [5, 10, 15, 20];
-  static const UPDATE_INTERVAL_FREQUENCY_VALUES = const [1, 2, 3, 4, 5, 10, 20, 30];
+  static const UPDATE_INTERVAL_VALUES = const [1, 2, 3, 4, 5, 10, 20, 30];
 
   // region IDS
   //IDS
@@ -156,7 +156,7 @@ class SettingsDao extends DatabaseAccessor<LighthouseDatabase>
         .map((event) {
       if (event != null && event.data != null) {
         final number = int.tryParse(event.data!, radix: 10);
-        if (number != null && UPDATE_INTERVAL_FREQUENCY_VALUES.contains(number)) {
+        if (number != null && UPDATE_INTERVAL_VALUES.contains(number)) {
           return number;
         }
       }

--- a/lib/data/local/MainPageSettings.dart
+++ b/lib/data/local/MainPageSettings.dart
@@ -15,6 +15,7 @@ class MainPageSettings {
     required this.sleepState,
     required this.viveBaseStationsEnabled,
     required this.scanDuration,
+    required this.updateInterval,
     required this.shortcutEnabled,
     required this.groupShowOfflineWarning,
   });
@@ -22,6 +23,7 @@ class MainPageSettings {
   final LighthousePowerState sleepState;
   final bool viveBaseStationsEnabled;
   final int scanDuration;
+  final int updateInterval;
   final bool shortcutEnabled;
   final bool groupShowOfflineWarning;
 
@@ -29,6 +31,7 @@ class MainPageSettings {
     sleepState: LighthousePowerState.SLEEP,
     viveBaseStationsEnabled: false,
     scanDuration: 5,
+    updateInterval: 1,
     shortcutEnabled: false,
     groupShowOfflineWarning: true,
   );
@@ -39,6 +42,7 @@ class MainPageSettings {
     bool viveBaseStationsEnabled =
         DEFAULT_MAIN_PAGE_SETTINGS.viveBaseStationsEnabled;
     int scanDuration = DEFAULT_MAIN_PAGE_SETTINGS.scanDuration;
+    int updateInterval = DEFAULT_MAIN_PAGE_SETTINGS.updateInterval;
     bool shortcutEnabled = DEFAULT_MAIN_PAGE_SETTINGS.shortcutEnabled;
     bool groupShowOfflineWarning =
         DEFAULT_MAIN_PAGE_SETTINGS.groupShowOfflineWarning;
@@ -53,10 +57,13 @@ class MainPageSettings {
           .getScanDurationsAsStream(defaultValue: scanDuration)
           .map((state) => Tuple2(SettingsDao.SCAN_DURATION_ID, state)),
       bloc.settings
+          .getUpdateIntervalAsStream(defaultUpdateInterval: updateInterval)
+          .map((state) => Tuple2(SettingsDao.UPDATE_INTERVAL_ID, state)),
+      bloc.settings
           .getShortcutsEnabledStream()
           .map((state) => Tuple2(SettingsDao.SHORTCUTS_ENABLED_ID, state)),
       bloc.settings.getGroupOfflineWarningEnabledStream().map(
-          (state) => Tuple2(SettingsDao.GROUP_SHOW_OFFLINE_WARNING, state)),
+          (state) => Tuple2(SettingsDao.GROUP_SHOW_OFFLINE_WARNING_ID, state)),
     ]).map((event) {
       switch (event.item1) {
         case SettingsDao.DEFAULT_SLEEP_STATE_ID:
@@ -74,12 +81,17 @@ class MainPageSettings {
             scanDuration = event.item2 as int;
           }
           break;
+        case SettingsDao.UPDATE_INTERVAL_ID:
+          if (event.item2 != null) {
+            updateInterval = event.item2 as int;
+          }
+          break;
         case SettingsDao.SHORTCUTS_ENABLED_ID:
           if (event.item2 != null) {
             shortcutEnabled = event.item2 as bool;
           }
           break;
-        case SettingsDao.GROUP_SHOW_OFFLINE_WARNING:
+        case SettingsDao.GROUP_SHOW_OFFLINE_WARNING_ID:
           if (event.item2 != null) {
             groupShowOfflineWarning = event.item2 as bool;
           }
@@ -89,6 +101,7 @@ class MainPageSettings {
         sleepState: sleepState,
         viveBaseStationsEnabled: viveBaseStationsEnabled,
         scanDuration: scanDuration,
+        updateInterval: updateInterval,
         shortcutEnabled: shortcutEnabled,
         groupShowOfflineWarning: groupShowOfflineWarning,
       );

--- a/lib/lighthouseProvider/DeviceProvider.dart
+++ b/lib/lighthouseProvider/DeviceProvider.dart
@@ -15,9 +15,10 @@ abstract class DeviceProvider<D extends LowLevelDevice> {
   /// Connect to a device and return a super class of [LighthouseDevice].
   ///
   /// [device] the specific device to connect to and test.
+  /// [updateInterval] The update time for the underlying devices.
   ///
   /// Can return `null` if the device is not support by this [DeviceProvider].
-  Future<LighthouseDevice?> getDevice(D device);
+  Future<LighthouseDevice?> getDevice(D device, {Duration? updateInterval});
 
   ///
   /// Close any open connections that may have been made for discovering devices.

--- a/lib/lighthouseProvider/LighthouseDevice.dart
+++ b/lib/lighthouseProvider/LighthouseDevice.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:lighthouse_pm/lighthouseProvider/ble/DeviceIdentifier.dart';
 import 'package:mutex/mutex.dart';
@@ -43,6 +44,13 @@ abstract class LighthouseDevice {
   LHDeviceIdentifier get deviceIdentifier;
 
   ///
+  /// The update interval for this device.
+  ///
+  @protected
+  @nonVirtual
+  Duration updateInterval = const Duration(milliseconds: 1000);
+
+  ///
   /// Disconnect from the device and clean up the connection.
   ///
   Future disconnect() async {
@@ -68,8 +76,22 @@ abstract class LighthouseDevice {
   /// Get the update interval that this device supports.
   ///
   @protected
-  Duration getUpdateInterval() {
+  Duration getMinUpdateInterval() {
     return const Duration(milliseconds: 1000);
+  }
+
+  @nonVirtual
+  Duration getUpdateInterval() {
+    final min = getMinUpdateInterval();
+    if (min < updateInterval) {
+      return updateInterval;
+    }
+    return min;
+  }
+
+  @nonVirtual
+  void setUpdateInterval(Duration interval) {
+    this.updateInterval = interval;
   }
 
   ///
@@ -169,7 +191,8 @@ abstract class LighthouseDevice {
       return;
     }
     powerStateSubscription =
-        Stream.periodic(getUpdateInterval()).listen((_) async {
+        MergeStream([Stream.value(null), Stream.periodic(getUpdateInterval())])
+            .listen((_) async {
       if (hasOpenConnection) {
         if (!transactionMutex.isLocked) {
           retryCount = 0;

--- a/lib/lighthouseProvider/LighthouseDevice.dart
+++ b/lib/lighthouseProvider/LighthouseDevice.dart
@@ -73,13 +73,19 @@ abstract class LighthouseDevice {
   LighthousePowerState powerStateFromByte(int byte);
 
   ///
-  /// Get the update interval that this device supports.
+  /// Get the minimum update interval that this device supports.
   ///
   @protected
   Duration getMinUpdateInterval() {
     return const Duration(milliseconds: 1000);
   }
 
+  ///
+  /// Get the update interval for the device state.
+  /// The update interval will never be lower than [getMinUpdateInterval] since
+  /// that is the fastest interval that the device support and shouldn't be
+  /// exceeded.
+  ///
   @nonVirtual
   Duration getUpdateInterval() {
     final min = getMinUpdateInterval();
@@ -89,6 +95,11 @@ abstract class LighthouseDevice {
     return min;
   }
 
+  ///
+  /// Set the prefered update interval for this device.
+  /// The update interval may be higher than the prefered value bacuase of the
+  /// value returned by [getMinUpdateInterval].
+  ///
   @nonVirtual
   void setUpdateInterval(Duration interval) {
     this.updateInterval = interval;

--- a/lib/lighthouseProvider/LighthouseProvider.dart
+++ b/lib/lighthouseProvider/LighthouseProvider.dart
@@ -121,13 +121,14 @@ class LighthouseProvider {
   /// for new ones.
   ///
   /// Will call the [cleanUp] function before starting the scan.
-  Future startScan({required Duration timeout}) async {
+  Future startScan(
+      {required Duration timeout, Duration? updateInterval}) async {
     await _startIsScanningSubscription();
     await cleanUp();
     await _startListeningScanResults();
     for (final backEnd in _backEndSet) {
       // may need to add await back again depending on how the providers react to being multi-threaded.
-      backEnd.startScan(timeout: timeout);
+      backEnd.startScan(timeout: timeout, updateInterval: updateInterval);
     }
   }
 

--- a/lib/lighthouseProvider/backEnd/FakeBLEBackEnd.dart
+++ b/lib/lighthouseProvider/backEnd/FakeBLEBackEnd.dart
@@ -34,8 +34,8 @@ class FakeBLEBackEnd extends BLELighthouseBackEnd {
   }
 
   @override
-  Future<void> startScan({required Duration timeout}) async {
-    await super.startScan(timeout: timeout);
+  Future<void> startScan({required Duration timeout, Duration? updateInterval}) async {
+    await super.startScan(timeout: timeout, updateInterval: updateInterval);
     _isScanningSubject.add(true);
     for (int i = 0; i < 2; i++) {
       await Future.delayed(Duration(milliseconds: random.nextInt(500) + 200));

--- a/lib/lighthouseProvider/backEnd/FlutterBlueLighthouseBackEnd.dart
+++ b/lib/lighthouseProvider/backEnd/FlutterBlueLighthouseBackEnd.dart
@@ -43,8 +43,9 @@ class FlutterBlueLighthouseBackEnd extends BLELighthouseBackEnd {
   ///
   /// Will call the [FlutterBlue.startScan] function in the background.
   @override
-  Future<void> startScan({required Duration timeout}) async {
-    await super.startScan(timeout: timeout);
+  Future<void> startScan(
+      {required Duration timeout, Duration? updateInterval}) async {
+    await super.startScan(timeout: timeout, updateInterval: updateInterval);
     await _startListeningScanResults();
     try {
       await FlutterBlue.instance.startScan(

--- a/lib/lighthouseProvider/backEnd/LighthouseBackEnd.dart
+++ b/lib/lighthouseProvider/backEnd/LighthouseBackEnd.dart
@@ -34,6 +34,8 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
   @protected
   Set<T> providers = Set();
 
+  /// The prefered update interval to use with getting the device state.
+  /// If `null` a default value will be used.
   @protected
   Duration? updateInterval;
 
@@ -68,9 +70,7 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
             ' It\'s still in debug mode so FIX it!');
       }
     }
-    if (updateInterval != null) {
-      this.updateInterval = updateInterval;
-    }
+    this.updateInterval = updateInterval;
   }
 
   /// Stop scanning for devices using this back end.

--- a/lib/lighthouseProvider/backEnd/LighthouseBackEnd.dart
+++ b/lib/lighthouseProvider/backEnd/LighthouseBackEnd.dart
@@ -34,6 +34,9 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
   @protected
   Set<T> providers = Set();
 
+  @protected
+  Duration? updateInterval;
+
   /// Add a provider for this back end.
   void addProvider(T provider) {
     providers.add(provider);
@@ -51,7 +54,8 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
   ///
   /// Any back end that implements this method MUST await the super function first.
   @mustCallSuper
-  Future<void> startScan({required Duration timeout}) async {
+  Future<void> startScan(
+      {required Duration timeout, Duration? updateInterval}) async {
     assert(updateLastSeen != null,
         'updateLastSeen should have been set by the LighthouseProvider!');
     if (providers.isEmpty) {
@@ -63,6 +67,9 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
         throw StateError('No device providers added for ${this.runtimeType}.'
             ' It\'s still in debug mode so FIX it!');
       }
+    }
+    if (updateInterval != null) {
+      this.updateInterval = updateInterval;
     }
   }
 
@@ -96,7 +103,7 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
         continue;
       }
       final LighthouseDevice? lighthouseDevice =
-          await provider.getDevice(device);
+          await provider.getDevice(device, updateInterval: updateInterval);
       if (lighthouseDevice != null) {
         return lighthouseDevice;
       }

--- a/lib/lighthouseProvider/deviceProviders/BLEDeviceProvider.dart
+++ b/lib/lighthouseProvider/deviceProviders/BLEDeviceProvider.dart
@@ -18,8 +18,12 @@ abstract class BLEDeviceProvider extends DeviceProvider<LHBluetoothDevice> {
   ///
   /// Can return `null` if the device is not support by this [DeviceProvider].
   @override
-  Future<LighthouseDevice?> getDevice(LHBluetoothDevice device) async {
+  Future<LighthouseDevice?> getDevice(LHBluetoothDevice device,
+      {Duration? updateInterval}) async {
     BLEDevice bleDevice = await this.internalGetDevice(device);
+    if (updateInterval != null) {
+      bleDevice.setUpdateInterval(updateInterval);
+    }
     this._bleDevicesDiscovering.add(bleDevice);
     try {
       final valid = await bleDevice.isValid();

--- a/lib/pages/MainPage.dart
+++ b/lib/pages/MainPage.dart
@@ -102,7 +102,10 @@ class _ScanFloatingButtonWidget extends StatelessWidget with ScanningMixin {
             onPressed: () async {
               if (await LocationPermissionDialogFlow
                   .showLocationPermissionDialogFlow(context)) {
-                await startScan(Duration(seconds: settings.scanDuration));
+                await startScan(
+                  Duration(seconds: settings.scanDuration),
+                  updateInterval: Duration(seconds: settings.updateInterval),
+                );
               }
             },
           );
@@ -139,6 +142,7 @@ class _ScanDevicesPage extends State<ScanDevicesPage>
     super.initState();
     WidgetsBinding.instance?.addObserver(this);
     startScanWithCheck(Duration(seconds: widget.settings.scanDuration),
+        updateInterval: Duration(seconds: widget.settings.updateInterval),
         failMessage:
             "Could not start scan because the permission has not been granted");
   }
@@ -379,7 +383,8 @@ class _ScanDevicesPage extends State<ScanDevicesPage>
                   settings: widget.settings,
                 ),
                 drawer: MainPageDrawer(
-                    Duration(seconds: widget.settings.scanDuration)),
+                    Duration(seconds: widget.settings.scanDuration),
+                    Duration(seconds: widget.settings.updateInterval)),
                 body: body,
               );
             }));
@@ -634,6 +639,7 @@ class _ScanDevicesPage extends State<ScanDevicesPage>
         break;
       case AppLifecycleState.resumed:
         startScanWithCheck(Duration(seconds: widget.settings.scanDuration),
+            updateInterval: Duration(seconds: widget.settings.updateInterval),
             failMessage:
                 "Could not start scan because the permission has not been granted on resume.");
         break;
@@ -675,7 +681,8 @@ class BluetoothOffScreen extends StatelessWidget with ScanningMixin {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.lightBlue,
-      drawer: MainPageDrawer(Duration(seconds: settings.scanDuration)),
+      drawer: MainPageDrawer(Duration(seconds: settings.scanDuration),
+          Duration(seconds: settings.updateInterval)),
       appBar: AppBar(
         title: Text('Lighthouse PM'),
       ),

--- a/lib/pages/SettingsPage.dart
+++ b/lib/pages/SettingsPage.dart
@@ -147,7 +147,7 @@ class SettingsPage extends BasePage with WithBlocStateless {
                       .setUpdateInterval(value);
                 }
               },
-              items: SettingsDao.UPDATE_INTERVAL_FREQUENCY_VALUES
+              items: SettingsDao.UPDATE_INTERVAL_VALUES
                   .map<DropdownMenuItem<int>>((int value) => DropdownMenuItem<int>(
                   value: value, child: Text('$value seconds')))
                   .toList());

--- a/lib/pages/SettingsPage.dart
+++ b/lib/pages/SettingsPage.dart
@@ -129,6 +129,31 @@ class SettingsPage extends BasePage with WithBlocStateless {
         },
       ),
       Divider(),
+      StreamBuilder<int>(
+        stream: blocWithoutListen(context).settings.getUpdateIntervalAsStream(),
+        builder: (BuildContext c, AsyncSnapshot<int> snapshot) {
+          if (!snapshot.hasData) {
+            return CircularProgressIndicator();
+          }
+          return DropdownMenuListTile<int>(
+              title: Text('Set update interval'),
+              subTitle: Text('You may want to change this if you have a lot'
+                  ' of devices.'),
+              value: snapshot.requireData,
+              onChanged: (int? value) async {
+                if (value != null) {
+                  await blocWithoutListen(context)
+                      .settings
+                      .setUpdateInterval(value);
+                }
+              },
+              items: SettingsDao.UPDATE_INTERVAL_FREQUENCY_VALUES
+                  .map<DropdownMenuItem<int>>((int value) => DropdownMenuItem<int>(
+                  value: value, child: Text('$value seconds')))
+                  .toList());
+        },
+      ),
+      Divider(),
       FutureBuilder<List<ThemeMode>>(
         future: _getSupportedThemeModes(),
         builder: (BuildContext context,

--- a/lib/pages/database/SettingsDaoPage.dart
+++ b/lib/pages/database/SettingsDaoPage.dart
@@ -27,8 +27,10 @@ class _SimpleSettingConverter extends DaoTableDataConverter<SimpleSetting> {
         return 'PREFERRED_THEME_ID';
       case SettingsDao.SHORTCUTS_ENABLED_ID:
         return 'SHORTCUTS_ENABLED_ID';
-      case SettingsDao.GROUP_SHOW_OFFLINE_WARNING:
+      case SettingsDao.GROUP_SHOW_OFFLINE_WARNING_ID:
         return 'GROUP_SHOW_OFFLINE_WARNING';
+      case SettingsDao.UPDATE_INTERVAL_ID:
+        return 'UPDATE_INTERVAL_ID';
       default:
         return 'UNKNOWN';
     }
@@ -87,8 +89,17 @@ class _SimpleSettingConverter extends DaoTableDataConverter<SimpleSetting> {
         return themeMode.toString();
       case SettingsDao.SHORTCUTS_ENABLED_ID:
         return convertToBoolean(data);
-      case SettingsDao.GROUP_SHOW_OFFLINE_WARNING:
+      case SettingsDao.GROUP_SHOW_OFFLINE_WARNING_ID:
         return convertToBoolean(data);
+      case SettingsDao.UPDATE_INTERVAL_ID:
+        if (data == null) {
+          return 'DEFAULT';
+        }
+        final value = int.tryParse(data, radix: 10);
+        if (value == null) {
+          return 'COULD-NOT-PARSE-VALUE';
+        }
+        return '$value seconds';
       default:
         return 'UNKNOWN CONVERSION';
     }

--- a/lib/pages/database/SettingsDaoPage.dart
+++ b/lib/pages/database/SettingsDaoPage.dart
@@ -28,7 +28,7 @@ class _SimpleSettingConverter extends DaoTableDataConverter<SimpleSetting> {
       case SettingsDao.SHORTCUTS_ENABLED_ID:
         return 'SHORTCUTS_ENABLED_ID';
       case SettingsDao.GROUP_SHOW_OFFLINE_WARNING_ID:
-        return 'GROUP_SHOW_OFFLINE_WARNING';
+        return 'GROUP_SHOW_OFFLINE_WARNING_ID';
       case SettingsDao.UPDATE_INTERVAL_ID:
         return 'UPDATE_INTERVAL_ID';
       default:

--- a/lib/widgets/MainPageDrawer.dart
+++ b/lib/widgets/MainPageDrawer.dart
@@ -6,9 +6,11 @@ import 'package:flutter_svg/svg.dart';
 import 'package:lighthouse_pm/widgets/ScanningMixin.dart';
 
 class MainPageDrawer extends StatelessWidget with ScanningMixin {
-  MainPageDrawer(this.scanDuration, {Key? key}) : super(key: key);
+  MainPageDrawer(this.scanDuration, this.updateInterval, {Key? key})
+      : super(key: key);
 
   final Duration scanDuration;
+  final Duration updateInterval;
 
   @override
   Widget build(BuildContext context) {
@@ -27,6 +29,7 @@ class MainPageDrawer extends StatelessWidget with ScanningMixin {
             cleanUp();
             await Navigator.pushNamed(context, '/troubleshooting');
             startScanWithCheck(scanDuration,
+                updateInterval: updateInterval,
                 failMessage:
                     "Could not start scan because permission has not been granted. On navigator pop");
           }),
@@ -38,6 +41,7 @@ class MainPageDrawer extends StatelessWidget with ScanningMixin {
           cleanUp();
           await Navigator.pushNamed(context, '/help');
           startScanWithCheck(scanDuration,
+              updateInterval: updateInterval,
               failMessage:
                   "Could not start scan because permission has not been granted. On navigator pop");
         },
@@ -50,6 +54,7 @@ class MainPageDrawer extends StatelessWidget with ScanningMixin {
           cleanUp();
           await Navigator.pushNamed(context, '/settings');
           startScanWithCheck(scanDuration,
+              updateInterval: updateInterval,
               failMessage:
                   "Could not start scan because permission has not been granted. On navigator pop");
         },
@@ -65,6 +70,7 @@ class MainPageDrawer extends StatelessWidget with ScanningMixin {
               cleanUp();
               await Navigator.pushNamed(context, '/databaseTest');
               startScanWithCheck(scanDuration,
+                  updateInterval: updateInterval,
                   failMessage:
                       "Could not start scan because permission has not been granted. On navigator pop");
             }),

--- a/lib/widgets/ScanningMixin.dart
+++ b/lib/widgets/ScanningMixin.dart
@@ -27,15 +27,16 @@ abstract class ScanningMixin {
     await LighthouseProvider.instance.stopScan();
   }
 
-  Future startScan(Duration scanDuration) async {
-    await LighthouseProvider.instance.startScan(timeout: scanDuration);
+  Future startScan(Duration scanDuration, {Duration? updateInterval}) async {
+    await LighthouseProvider.instance
+        .startScan(timeout: scanDuration, updateInterval: updateInterval);
   }
 
   Future startScanWithCheck(Duration scanDuration,
-      {String failMessage = ""}) async {
+      {Duration? updateInterval, String failMessage = ""}) async {
     if (await BLEPermissionsHelper.hasBLEPermissions() ==
         PermissionStatus.granted) {
-      await startScan(scanDuration);
+      await startScan(scanDuration, updateInterval: updateInterval);
     } else if (failMessage != null && failMessage.isNotEmpty && !kReleaseMode) {
       debugPrint(failMessage);
     }


### PR DESCRIPTION
Cleaned up import for shortcut.kt.
Updated changelog.
Propagate the update interval from the startScan all the way down to the LighthouseDevice.
Update interval can not be lower than the minimum update interval of a device type.

closes #73 