### PR TITLE
Fixed `groups` table not being renamed in the database migration

### DIFF
--- a/lib/data/tables/group_table.dart
+++ b/lib/data/tables/group_table.dart
@@ -12,8 +12,8 @@ class Groups extends Table {
 class GroupEntries extends Table {
   TextColumn get deviceId => text().withLength(min: 17, max: 37)();
 
-  IntColumn get groupId => integer().customConstraint(
-      'NOT NULL REFERENCES "groups"(deviceId) ON DELETE CASCADE ON UPDATE CASCADE')();
+  IntColumn get groupId => integer().references(Groups, #id,
+      onUpdate: KeyAction.cascade, onDelete: KeyAction.cascade)();
 
   @override
   Set<Column> get primaryKey => {deviceId};

--- a/test/data/migration_test.dart
+++ b/test/data/migration_test.dart
@@ -1,17 +1,18 @@
 import 'package:drift/drift.dart'
     show
-        QueryExecutor,
         MigrationStrategy,
-        driftRuntimeOptions,
         OpeningDetails,
-        QueryExecutorUser;
+        QueryExecutor,
+        QueryExecutorUser,
+        TransactionExecutor,
+        driftRuntimeOptions;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lighthouse_pm/data/database.dart';
 
 import 'migration_helpers/fake_migrator.dart';
 
-class FakeQueryExecutor extends Fake implements QueryExecutor {
+class FakeQueryExecutor extends Fake implements TransactionExecutor {
   @override
   Future<bool> ensureOpen(final QueryExecutorUser user) async {
     return true;
@@ -23,6 +24,21 @@ class FakeQueryExecutor extends Fake implements QueryExecutor {
   Future<void> runCustom(final String statement,
       [final List<Object?>? args]) async {
     lastStatement = statement;
+  }
+
+  @override
+  TransactionExecutor beginTransaction() {
+    return this;
+  }
+
+  @override
+  Future<void> send() async {
+    // doing nothing is nice.
+  }
+
+  @override
+  Future<void> rollback() async {
+    throw MigrationError("Got to a rollback, which shouldn't happen!");
   }
 }
 


### PR DESCRIPTION
In older version of drift the `groups` table was named `"groups"` and in newer versions it has been renamed to `groups` so it needs to be migrated.