### PR TITLE
Refactored `LighthouseDevice` to not be stateful

### DIFF
--- a/lib/data/dao/settings_dao.dart
+++ b/lib/data/dao/settings_dao.dart
@@ -60,7 +60,7 @@ class SettingsDao extends DatabaseAccessor<LighthouseDatabase>
         'The new sleep state cannot be ${sleepState.text.toUpperCase()}');
     return into(simpleSettings).insert(
         SimpleSetting(
-            settingsId: defaultSleepStateId, data: sleepState.id.toString()),
+            settingsId: defaultSleepStateId, data: sleepState.index.toString()),
         mode: InsertMode.insertOrReplace);
   }
 

--- a/lib/lighthouse_provider/widgets/unknown_state_alert_widget.dart
+++ b/lib/lighthouse_provider/widgets/unknown_state_alert_widget.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:lighthouse_provider/lighthouse_provider.dart';
-import 'package:lighthouse_providers/lighthouse_v2_device_provider.dart';
 import 'package:lighthouse_pm/links.dart';
 import 'package:lighthouse_pm/theming.dart';
+import 'package:lighthouse_provider/lighthouse_provider.dart';
+import 'package:lighthouse_providers/lighthouse_v2_device_provider.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:toast/toast.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -14,9 +14,8 @@ import '../helpers/custom_long_press_gesture_recognizer.dart';
 
 /// An alert dialog to ask the user what to do since the state is unknown.
 class UnknownStateAlertWidget extends StatelessWidget {
-  const UnknownStateAlertWidget(this.device, this.currentState,
-      {final Key? key})
-      : super(key: key);
+  const UnknownStateAlertWidget(this.device,
+      {required this.currentState, super.key});
 
   final LighthouseDevice device;
   final int currentState;
@@ -68,7 +67,8 @@ class UnknownStateAlertWidget extends StatelessWidget {
               recognizer: TapGestureRecognizer()
                 ..onTap = () async {
                   await UnknownStateHelpOutAlertWidget.showCustomDialog(
-                      context, device, currentState);
+                      context, device,
+                      currentState: currentState);
                 },
             )
           ]),
@@ -77,31 +77,36 @@ class UnknownStateAlertWidget extends StatelessWidget {
   }
 
   static Future<LighthousePowerState?> showCustomDialog(
-      final BuildContext context,
-      final LighthouseDevice device,
-      final int currentState) {
+      final BuildContext context, final LighthouseDevice device,
+      {final int? currentState}) async {
+    if (currentState == null) {
+      return null;
+    }
     return showDialog(
         context: context,
         builder: (final BuildContext context) {
-          return UnknownStateAlertWidget(device, currentState);
+          return UnknownStateAlertWidget(device, currentState: currentState);
         });
   }
 }
 
 /// A dialog to ask the user to help out with unknown states
 class UnknownStateHelpOutAlertWidget extends StatelessWidget {
-  const UnknownStateHelpOutAlertWidget(this.device, this.currentState,
-      {final Key? key})
-      : super(key: key);
+  const UnknownStateHelpOutAlertWidget(this.device,
+      {this.currentState, super.key});
 
   final LighthouseDevice device;
-  final int currentState;
+  final int? currentState;
 
   String _getClipboardString(final String version) {
-    return 'App version: $version\n'
+    var output = 'App version: $version\n'
         'Device type: ${device.runtimeType}\n'
-        'Firmware version: ${device.firmwareVersion}\n'
-        'Current reported state: 0x${currentState.toRadixString(16).padLeft(2, '0')}\n';
+        'Firmware version: ${device.firmwareVersion}\n';
+    if (currentState != null) {
+      output +=
+          'Current reported state: 0x${currentState!.toRadixString(16).padLeft(2, '0')}\n';
+    }
+    return output;
   }
 
   GestureRecognizer createRecognizer(
@@ -162,15 +167,17 @@ class UnknownStateHelpOutAlertWidget extends StatelessWidget {
               text: '${device.firmwareVersion}\n',
               recognizer: recognizer,
             ),
-            TextSpan(
-              text: 'Current reported state: ',
-              recognizer: recognizer,
-            ),
-            TextSpan(
-              style: theming.bodyTextBold,
-              text: '0x${currentState.toRadixString(16).padLeft(2, '0')}\n',
-              recognizer: recognizer,
-            ),
+            if (currentState != null) ...[
+              TextSpan(
+                text: 'Current reported state: ',
+                recognizer: recognizer,
+              ),
+              TextSpan(
+                style: theming.bodyTextBold,
+                text: '0x${currentState!.toRadixString(16).padLeft(2, '0')}\n',
+                recognizer: recognizer,
+              ),
+            ],
           ]));
         },
       ),
@@ -192,12 +199,14 @@ class UnknownStateHelpOutAlertWidget extends StatelessWidget {
     );
   }
 
-  static Future<void> showCustomDialog(final BuildContext context,
-      final LighthouseDevice device, final int currentState) {
+  static Future<void> showCustomDialog(
+      final BuildContext context, final LighthouseDevice device,
+      {final int? currentState}) {
     return showDialog(
         context: context,
         builder: (final BuildContext context) {
-          return UnknownStateHelpOutAlertWidget(device, currentState);
+          return UnknownStateHelpOutAlertWidget(device,
+              currentState: currentState);
         });
   }
 }

--- a/lib/lighthouse_provider/widgets/widget_for_extension.dart
+++ b/lib/lighthouse_provider/widgets/widget_for_extension.dart
@@ -79,7 +79,6 @@ ButtonStyle? getButtonStyleFromState(
     case LighthousePowerState.unknown:
       return ElevatedButton.styleFrom(shape: const CircleBorder());
   }
-  return null;
 }
 
 ButtonStyle? getButtonStyleFromDeviceExtension(

--- a/lib/pages/shortcut/states/get_device_state_stream.dart
+++ b/lib/pages/shortcut/states/get_device_state_stream.dart
@@ -22,7 +22,7 @@ class GetDeviceStateStream extends WaterfallStreamWidget<LighthousePowerState>
             downStreamBuilders: downStreamBuilders);
 
   Stream<WithTimeout<LighthousePowerState>> getDeviceState(
-      final LighthouseDevice device, final Duration timeout) {
+      final StatefulLighthouseDevice device, final Duration timeout) {
     final timeoutStream = Stream.fromFutures([
       Future.value(false),
       Future.delayed(timeout).then(((final val) => true))
@@ -69,7 +69,7 @@ class GetDeviceStateStream extends WaterfallStreamWidget<LighthousePowerState>
             'Illegal state, the settingsIndex isn\'t an instance of MainPageSettings. upStream[$settingsIndex]');
       }
     }
-    final device = upStream.last as LighthouseDevice;
+    final device = upStream.last as StatefulLighthouseDevice;
     final settings = upStream[settingsIndex] as MainPageSettings;
     return StreamBuilder<WithTimeout<LighthousePowerState>>(
         stream: getDeviceState(

--- a/lighthouse_provider/lighthouse_back_end/lib/src/device_provider/ble_device_provider.dart
+++ b/lighthouse_provider/lighthouse_back_end/lib/src/device_provider/ble_device_provider.dart
@@ -44,8 +44,8 @@ abstract class BLEDeviceProvider<T> extends DeviceProvider<LHBluetoothDevice> {
   Future<LighthouseDevice?> getDevice(final LHBluetoothDevice device,
       {final Duration? updateInterval}) async {
     final BLEDevice bleDevice = await internalGetDevice(device);
-    if (updateInterval != null) {
-      bleDevice.setUpdateInterval(updateInterval);
+    if (updateInterval != null && bleDevice is StatefulLighthouseDevice) {
+      (bleDevice as StatefulLighthouseDevice).setUpdateInterval(updateInterval);
     }
     bleDevicesDiscovering.add(bleDevice);
     try {

--- a/lighthouse_provider/lighthouse_back_ends/fake_back_end/pubspec.yaml
+++ b/lighthouse_provider/lighthouse_back_ends/fake_back_end/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
-  flutter_web_bluetooth: ^0.0.9
+  flutter_web_bluetooth: ^0.1.0
   meta: ^1.8.0
   mutex: ^3.0.0
   rxdart: ^0.27.5

--- a/lighthouse_provider/lighthouse_back_ends/flutter_web_bluetooth_back_end/pubspec.yaml
+++ b/lighthouse_provider/lighthouse_back_ends/flutter_web_bluetooth_back_end/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 
 dependencies:
-  flutter_web_bluetooth: ^0.0.9
+  flutter_web_bluetooth: ^0.1.0
   mutex: ^3.0.0
   rxdart: ^0.27.5
   lighthouse_back_end:

--- a/lighthouse_provider/lighthouse_provider/lib/lighthouse_provider.dart
+++ b/lighthouse_provider/lighthouse_provider/lib/lighthouse_provider.dart
@@ -21,6 +21,7 @@ part 'src/ble/device_identifier.dart';
 part 'src/ble/guid.dart';
 
 part 'src/devices/lighthouse_device.dart';
+part 'src/devices/stateful_lighthouse_device.dart';
 
 part 'src/devices/lighthouse_power_state.dart';
 

--- a/lighthouse_provider/lighthouse_provider/lib/src/devices/lighthouse_device.dart
+++ b/lighthouse_provider/lighthouse_provider/lib/src/devices/lighthouse_device.dart
@@ -37,21 +37,9 @@ abstract class LighthouseDevice {
   LHDeviceIdentifier get deviceIdentifier;
 
   ///
-  /// The update interval for this device.
-  ///
-  @protected
-  @nonVirtual
-  Duration updateInterval = const Duration(milliseconds: 1000);
-
-  ///
   /// Disconnect from the device and clean up the connection.
   ///
   Future disconnect() async {
-    await _powerStateSubscription?.cancel();
-    // ignore: unnecessary_null_comparison
-    if (_powerState != null && !_powerState.isClosed) {
-      _powerState.close();
-    }
     await internalDisconnect();
   }
 
@@ -60,65 +48,6 @@ abstract class LighthouseDevice {
   ///
   @protected
   Future internalDisconnect();
-
-  ///
-  /// Convert a device specific state byte to a global `LighthousePowerState`.
-  ///
-  LighthousePowerState powerStateFromByte(final int byte);
-
-  ///
-  /// Get the minimum update interval that this device supports.
-  ///
-  @visibleForTesting
-  @protected
-  Duration getMinUpdateInterval() {
-    return const Duration(milliseconds: 1000);
-  }
-
-  ///
-  /// Overwrite the minimum update interval for testing.
-  ///
-  @visibleForTesting
-  Duration? testingOverwriteMinUpdateInterval;
-
-  ///
-  /// Get the update interval for the device state.
-  /// The update interval will never be lower than [getMinUpdateInterval] since
-  /// that is the fastest interval that the device support and shouldn't be
-  /// exceeded.
-  ///
-  @nonVirtual
-  Duration getUpdateInterval() {
-    var min = getMinUpdateInterval();
-    assert(() {
-      if (testingOverwriteMinUpdateInterval != null) {
-        lighthouseLogger.config("Overwritten min update interval, "
-            "stuttering devices may be in your future");
-        min = testingOverwriteMinUpdateInterval!;
-      }
-      return true;
-    }());
-    if (min < updateInterval) {
-      return updateInterval;
-    }
-    return min;
-  }
-
-  ///
-  /// Set the preferred update interval for this device.
-  /// The update interval may be higher than the preferred value because of the
-  /// value returned by [getMinUpdateInterval].
-  ///
-  @nonVirtual
-  void setUpdateInterval(final Duration interval) {
-    updateInterval = interval;
-  }
-
-  ///
-  /// Get the current power state as a device specific byte.
-  ///
-  @protected
-  Future<int?> getCurrentState();
 
   ///
   /// Change the actual state of the device.
@@ -131,21 +60,6 @@ abstract class LighthouseDevice {
   /// If the device has an open connection.
   ///
   bool get hasOpenConnection;
-
-  /// Get the power state of the device as a device specific int.
-  Stream<int> get powerState {
-    _startPowerStateStream();
-    return _powerState.stream;
-  }
-
-  ///Get the power state of the device as a [LighthousePowerState] "enum".
-  Stream<LighthousePowerState> get powerStateEnum => powerState.map((final e) {
-        return powerStateFromByte(e);
-      });
-
-  // ignore: close_sinks
-  final BehaviorSubject<int> _powerState = BehaviorSubject.seeded(0xFF);
-  StreamSubscription? _powerStateSubscription;
 
   ///
   /// This is the mutex used for transactions.
@@ -216,65 +130,5 @@ abstract class LighthouseDevice {
   ///
   Future<bool> requestExtraInfo<C>([final C? context]) async {
     return true;
-  }
-
-  /// Start the power state stream.
-  ///
-  /// If this method is called while there is already an active stream then it
-  /// will do nothing.
-  void _startPowerStateStream() {
-    final stack = StackTrace.current;
-    int retryCount = 0;
-    var powerStateSubscription = _powerStateSubscription;
-    if (powerStateSubscription != null) {
-      if (powerStateSubscription.isPaused) {
-        powerStateSubscription.resume();
-        return;
-      }
-      return;
-    }
-    powerStateSubscription =
-        MergeStream([Stream.value(null), Stream.periodic(getUpdateInterval())])
-            .listen((final _) async {
-      if (hasOpenConnection) {
-        if (!transactionMutex.isLocked) {
-          retryCount = 0;
-          try {
-            await transactionMutex.acquire(stack);
-            final data = await getCurrentState().timeout(Duration(seconds: 5));
-            if (_powerState.isClosed) {
-              await disconnect();
-              return;
-            }
-            if (data != null) {
-              _powerState.add(data);
-            }
-          } catch (e, s) {
-            lighthouseLogger.severe(
-                "Could not get state, maybe the device is already disconnected",
-                e,
-                s);
-            await disconnect();
-            return;
-          } finally {
-            transactionMutex.release();
-          }
-        } else {
-          if (retryCount++ > 5) {
-            lighthouseLogger.shout("Unable to get power state because the "
-                "mutex has been locked for a while ($retryCount)."
-                "\nLocked by: ${transactionMutex.lockTrace?.toString()}");
-          }
-        }
-      } else {
-        lighthouseLogger.info("Cleaning-up old subscription!");
-        disconnect();
-      }
-    });
-    powerStateSubscription.onDone(() {
-      lighthouseLogger.info("Cleaning-up power state subscription!");
-      _powerStateSubscription = null;
-    });
-    _powerStateSubscription = powerStateSubscription;
   }
 }

--- a/lighthouse_provider/lighthouse_provider/lib/src/devices/lighthouse_power_state.dart
+++ b/lighthouse_provider/lighthouse_provider/lib/src/devices/lighthouse_power_state.dart
@@ -1,29 +1,18 @@
 part of lighthouse_provider;
 
 /// An enum that describes the current power state of a lighthouse beacon.
-class LighthousePowerState {
+///
+enum LighthousePowerState {
+  sleep('Sleep'),
+  on('On'),
+  unknown('Unknown'),
+  booting('Booting'),
+  standby('Standby'),
+  ;
+
   final String text;
 
-  ///
-  /// This is for storing into the data base. These should all be unique and
-  /// not change between versions!
-  final int id;
-
-  const LighthousePowerState._internal(this.text, this.id);
-
-  static const sleep = LighthousePowerState._internal('Sleep', 0);
-  static const on = LighthousePowerState._internal('On', 1);
-  static const unknown = LighthousePowerState._internal('Unknown', 2);
-  static const booting = LighthousePowerState._internal('Booting', 3);
-  static const standby = LighthousePowerState._internal('Standby', 4);
-
-  static const values = [
-    sleep,
-    on,
-    unknown,
-    booting,
-    standby,
-  ];
+  const LighthousePowerState(this.text);
 
   static LighthousePowerState fromId(final int id) {
     if (id >= 0 && id < values.length) {
@@ -34,6 +23,6 @@ class LighthousePowerState {
 
   @override
   String toString() {
-    return "$text ($id)";
+    return "$text ($index)";
   }
 }

--- a/lighthouse_provider/lighthouse_provider/lib/src/devices/stateful_lighthouse_device.dart
+++ b/lighthouse_provider/lighthouse_provider/lib/src/devices/stateful_lighthouse_device.dart
@@ -1,0 +1,157 @@
+part of lighthouse_provider;
+
+mixin StatefulLighthouseDevice on LighthouseDevice {
+  ///
+  /// Disconnect from the device and clean up the connection.
+  ///
+  @override
+  Future disconnect() async {
+    await _powerStateSubscription?.cancel();
+    // ignore: unnecessary_null_comparison
+    if (_powerState != null && !_powerState.isClosed) {
+      _powerState.close();
+    }
+    return super.disconnect();
+  }
+
+  ///
+  /// The update interval for this device.
+  ///
+  @protected
+  @nonVirtual
+  Duration updateInterval = const Duration(milliseconds: 1000);
+
+  ///
+  /// Convert a device specific state byte to a global `LighthousePowerState`.
+  ///
+  LighthousePowerState powerStateFromByte(final int byte);
+
+  ///
+  /// Get the minimum update interval that this device supports.
+  ///
+  @visibleForTesting
+  @protected
+  Duration getMinUpdateInterval() {
+    return const Duration(milliseconds: 1000);
+  }
+
+  ///
+  /// Overwrite the minimum update interval for testing.
+  ///
+  @visibleForTesting
+  Duration? testingOverwriteMinUpdateInterval;
+
+  ///
+  /// Get the update interval for the device state.
+  /// The update interval will never be lower than [getMinUpdateInterval] since
+  /// that is the fastest interval that the device support and shouldn't be
+  /// exceeded.
+  ///
+  @nonVirtual
+  Duration getUpdateInterval() {
+    var min = getMinUpdateInterval();
+    assert(() {
+      if (testingOverwriteMinUpdateInterval != null) {
+        lighthouseLogger.config("Overwritten min update interval, "
+            "stuttering devices may be in your future");
+        min = testingOverwriteMinUpdateInterval!;
+      }
+      return true;
+    }());
+    if (min < updateInterval) {
+      return updateInterval;
+    }
+    return min;
+  }
+
+  ///
+  /// Set the preferred update interval for this device.
+  /// The update interval may be higher than the preferred value because of the
+  /// value returned by [getMinUpdateInterval].
+  ///
+  @nonVirtual
+  void setUpdateInterval(final Duration interval) {
+    updateInterval = interval;
+  }
+
+  ///
+  /// Get the current power state as a device specific byte.
+  ///
+  @protected
+  Future<int?> getCurrentState();
+
+  /// Get the power state of the device as a device specific int.
+  Stream<int> get powerState {
+    _startPowerStateStream();
+    return _powerState.stream;
+  }
+
+  ///Get the power state of the device as a [LighthousePowerState] "enum".
+  Stream<LighthousePowerState> get powerStateEnum => powerState.map((final e) {
+        return powerStateFromByte(e);
+      });
+
+  // ignore: close_sinks
+  final BehaviorSubject<int> _powerState = BehaviorSubject.seeded(0xFF);
+  StreamSubscription? _powerStateSubscription;
+
+  /// Start the power state stream.
+  ///
+  /// If this method is called while there is already an active stream then it
+  /// will do nothing.
+  void _startPowerStateStream() {
+    final stack = StackTrace.current;
+    int retryCount = 0;
+    var powerStateSubscription = _powerStateSubscription;
+    if (powerStateSubscription != null) {
+      if (powerStateSubscription.isPaused) {
+        powerStateSubscription.resume();
+        return;
+      }
+      return;
+    }
+    powerStateSubscription =
+        MergeStream([Stream.value(null), Stream.periodic(getUpdateInterval())])
+            .listen((final _) async {
+      if (hasOpenConnection) {
+        if (!transactionMutex.isLocked) {
+          retryCount = 0;
+          try {
+            await transactionMutex.acquire(stack);
+            final data = await getCurrentState().timeout(Duration(seconds: 5));
+            if (_powerState.isClosed) {
+              await disconnect();
+              return;
+            }
+            if (data != null) {
+              _powerState.add(data);
+            }
+          } catch (e, s) {
+            lighthouseLogger.severe(
+                "Could not get state, maybe the device is already disconnected",
+                e,
+                s);
+            await disconnect();
+            return;
+          } finally {
+            transactionMutex.release();
+          }
+        } else {
+          if (retryCount++ > 5) {
+            lighthouseLogger.shout("Unable to get power state because the "
+                "mutex has been locked for a while ($retryCount)."
+                "\nLocked by: ${transactionMutex.lockTrace?.toString()}");
+          }
+        }
+      } else {
+        lighthouseLogger.info("Cleaning-up old subscription!");
+        disconnect();
+      }
+    });
+    powerStateSubscription.onDone(() {
+      lighthouseLogger.info("Cleaning-up power state subscription!");
+      _powerStateSubscription = null;
+    });
+    _powerStateSubscription = powerStateSubscription;
+  }
+}

--- a/lighthouse_provider/lighthouse_provider/test/devices/lighthouse_device_test.dart
+++ b/lighthouse_provider/lighthouse_provider/test/devices/lighthouse_device_test.dart
@@ -24,7 +24,7 @@ void main() {
   });
 
   test('Update interval should not be less than the minimum', () {
-    final device = FakeHighLevelDevice(FakeLighthouseV2Device(0, 0));
+    final device = FakeHighLevelStatefulDevice(FakeLighthouseV2Device(0, 0));
 
     device.setUpdateInterval(Duration(milliseconds: 1000));
     expect(device.getUpdateInterval(), Duration(milliseconds: 1000));
@@ -77,7 +77,7 @@ void main() {
   });
 
   test('Should disconnect if could not get current state', () async {
-    final device = FakeHighLevelDevice(FakeLighthouseV2Device(0, 0));
+    final device = FakeHighLevelStatefulDevice(FakeLighthouseV2Device(0, 0));
     device.openConnection = true;
 
     try {
@@ -96,7 +96,7 @@ void main() {
   });
 
   test('Should clean up if there is no open connection', () async {
-    final device = FakeHighLevelDevice(FakeLighthouseV2Device(0, 0));
+    final device = FakeHighLevelStatefulDevice(FakeLighthouseV2Device(0, 0));
     device.openConnection = false;
 
     try {

--- a/lighthouse_provider/lighthouse_providers/lib/src/lighthouse_v2/device/lighthouse_v2_device.dart
+++ b/lighthouse_provider/lighthouse_providers/lib/src/lighthouse_v2/device/lighthouse_v2_device.dart
@@ -6,6 +6,7 @@ part of lighthouse_v2_device_provider;
 ///The characteristic that handles the power state of the device.
 
 class LighthouseV2Device extends BLEDevice<LighthouseV2Persistence>
+    with StatefulLighthouseDevice
     implements DeviceWithExtensions {
   static const String powerCharacteristicUUID =
       '00001525-1212-efde-1523-785feabcd124';

--- a/lighthouse_provider/lighthouse_providers/pubspec.yaml
+++ b/lighthouse_provider/lighthouse_providers/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 
 dependencies:
-  flutter_web_bluetooth: ^0.0.9
+  flutter_web_bluetooth: ^0.1.0
   meta: ^1.8.0
   rxdart: ^0.27.5
   lighthouse_provider:

--- a/lighthouse_provider/lighthouse_providers/test/lighthouse_v2/device/lighthouse_v2_device_test.dart
+++ b/lighthouse_provider/lighthouse_providers/test/lighthouse_v2/device/lighthouse_v2_device_test.dart
@@ -674,8 +674,10 @@ void main() {
   });
 }
 
-Future<LighthousePowerState> getNextPowerState(final LighthouseDevice device,
-    final LighthousePowerState previous, final Duration timeout) async {
+Future<LighthousePowerState> getNextPowerState(
+    final StatefulLighthouseDevice device,
+    final LighthousePowerState previous,
+    final Duration timeout) async {
   return device.powerStateEnum
       .firstWhere((final element) => element != previous)
       .timeout(timeout);

--- a/lighthouse_provider/lighthouse_providers/test/vive_base_station/device/vive_base_station_device_test.dart
+++ b/lighthouse_provider/lighthouse_providers/test/vive_base_station/device/vive_base_station_device_test.dart
@@ -374,28 +374,15 @@ void main() {
         FakeViveBaseStationDevice(0, 0), persistence, null);
     persistence.insertId(device.deviceIdentifier, 0x12345678);
 
-    device.testingOverwriteMinUpdateInterval = Duration(milliseconds: 10);
-    device.setUpdateInterval(Duration(milliseconds: 10));
-
     final valid = await device.isValid();
     expect(valid, true);
 
     //First turn off the device
     await device.changeState(LighthousePowerState.sleep);
-    final currentState = await device.powerStateEnum
-        .firstWhere((final element) => element == LighthousePowerState.unknown)
-        .timeout(Duration(seconds: 3));
-
-    expect(currentState, LighthousePowerState.unknown);
 
     //Now turn it on
     await device.changeState(LighthousePowerState.on);
 
-    final nextState = await device.powerStateEnum
-        .firstWhere((final element) => element == LighthousePowerState.unknown)
-        .timeout(Duration(seconds: 3));
-
-    expect(nextState, LighthousePowerState.unknown);
     expect(device.transactionMutex.isLocked, false,
         reason: "Transaction mutex should have been released");
   });
@@ -408,28 +395,15 @@ void main() {
         FakeViveBaseStationDevice(0, 0), persistence, null);
     persistence.insertId(device.deviceIdentifier, 0x12345678);
 
-    device.testingOverwriteMinUpdateInterval = Duration(milliseconds: 10);
-    device.setUpdateInterval(Duration(milliseconds: 10));
-
     final valid = await device.isValid();
     expect(valid, true);
 
     //First turn on the device
     await device.changeState(LighthousePowerState.on);
-    final currentState = await device.powerStateEnum
-        .firstWhere((final element) => element == LighthousePowerState.unknown)
-        .timeout(Duration(seconds: 3));
-
-    expect(currentState, LighthousePowerState.unknown);
 
     //Now set it to sleep
     await device.changeState(LighthousePowerState.sleep);
 
-    final nextState = await device.powerStateEnum
-        .firstWhere((final element) => element == LighthousePowerState.unknown)
-        .timeout(Duration(seconds: 3));
-
-    expect(nextState, LighthousePowerState.unknown);
     expect(device.transactionMutex.isLocked, false,
         reason: "Transaction mutex should have been released");
   });
@@ -441,9 +415,6 @@ void main() {
     final device = ViveBaseStationDevice(
         FakeViveBaseStationDevice(0, 0), persistence, null);
     persistence.insertId(device.deviceIdentifier, 0x12345678);
-
-    device.testingOverwriteMinUpdateInterval = Duration(milliseconds: 10);
-    device.setUpdateInterval(Duration(milliseconds: 10));
 
     final valid = await device.isValid();
     expect(valid, true);
@@ -472,20 +443,11 @@ void main() {
       return null;
     });
 
-    device.testingOverwriteMinUpdateInterval = Duration(milliseconds: 10);
-    device.setUpdateInterval(Duration(milliseconds: 10));
-
     final valid = await device.isValid();
     expect(valid, true);
 
-    final start = await device.powerState
-        .firstWhere((final element) => element != 0xFF)
-        .timeout(Duration(seconds: 2));
-
     await device.changeState(LighthousePowerState.on);
 
-    final next = await device.powerState.first;
-    expect(next, start);
     expect(device.transactionMutex.isLocked, false,
         reason: "Transaction mutex should have been released");
   });

--- a/lighthouse_provider/lighthouse_test_helper/lib/src/fake_high_level_device.dart
+++ b/lighthouse_provider/lighthouse_test_helper/lib/src/fake_high_level_device.dart
@@ -6,6 +6,23 @@ import 'package:lighthouse_provider/device_extensions/device_extension.dart';
 import 'package:lighthouse_provider/lighthouse_provider.dart';
 import 'package:meta/meta.dart';
 
+class FakeHighLevelStatefulDevice extends FakeHighLevelDevice
+    with StatefulLighthouseDevice {
+  FakeHighLevelStatefulDevice(final LHBluetoothDevice device) : super(device);
+
+  FakeHighLevelStatefulDevice.simple() : this(FakeLighthouseV2Device(1, 1));
+
+  @override
+  Future<int?> getCurrentState() {
+    throw UnimplementedError();
+  }
+
+  @override
+  LighthousePowerState powerStateFromByte(final int byte) {
+    throw UnimplementedError();
+  }
+}
+
 @visibleForTesting
 class FakeHighLevelDevice extends BLEDevice implements DeviceWithExtensions {
   FakeHighLevelDevice(final LHBluetoothDevice device) : super(device, null);
@@ -20,11 +37,6 @@ class FakeHighLevelDevice extends BLEDevice implements DeviceWithExtensions {
 
   @override
   String get firmwareVersion => "WOW firmware";
-
-  @override
-  Future<int?> getCurrentState() {
-    throw UnimplementedError();
-  }
 
   bool openConnection = false;
 
@@ -56,11 +68,6 @@ class FakeHighLevelDevice extends BLEDevice implements DeviceWithExtensions {
 
   @override
   Map<String, String?> get otherMetadata => throw UnimplementedError();
-
-  @override
-  LighthousePowerState powerStateFromByte(final int byte) {
-    throw UnimplementedError();
-  }
 
   @override
   Future<bool> isValid() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -334,7 +334,7 @@ packages:
       name: flutter_web_bluetooth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.9"
+    version: "0.1.0"
   flutter_web_bluetooth_back_end:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   flutter_blue_back_end:
     path: lighthouse_provider/lighthouse_back_ends/flutter_blue_back_end
   # Web:
-  flutter_web_bluetooth: ^0.0.9
+  flutter_web_bluetooth: ^0.1.0
   web_browser_detect: ^2.0.3
   flutter_web_bluetooth_back_end:
     path: lighthouse_provider/lighthouse_back_ends/flutter_web_bluetooth_back_end

--- a/test/lighthouse_provider/widgets/unknown_state_alert_widget_test.dart
+++ b/test/lighthouse_provider/widgets/unknown_state_alert_widget_test.dart
@@ -21,7 +21,8 @@ void main() {
     SharedPlatform.overridePlatform = null;
 
     await tester.pumpWidget(buildTestAppForWidgets((final context) {
-      UnknownStateAlertWidget.showCustomDialog(context, device, 0xFF);
+      UnknownStateAlertWidget.showCustomDialog(context, device,
+          currentState: 0xFF);
     }));
 
     await tester.tap(find.text('X'));
@@ -54,7 +55,8 @@ void main() {
     SharedPlatform.overridePlatform = null;
 
     await tester.pumpWidget(buildTestAppForWidgets((final context) {
-      UnknownStateAlertWidget.showCustomDialog(context, device, 0xFF);
+      UnknownStateAlertWidget.showCustomDialog(context, device,
+          currentState: 0xFF);
     }));
 
     await tester.tap(find.text('X'));
@@ -84,7 +86,8 @@ void main() {
     SharedPlatform.overridePlatform = null;
 
     await tester.pumpWidget(buildTestAppForWidgets((final context) {
-      UnknownStateAlertWidget.showCustomDialog(context, device, 0xFF);
+      UnknownStateAlertWidget.showCustomDialog(context, device,
+          currentState: 0xFF);
     }));
 
     await tester.tap(find.text('X'));
@@ -115,7 +118,8 @@ void main() {
     SharedPlatform.overridePlatform = null;
 
     await tester.pumpWidget(buildTestAppForWidgets((final context) {
-      future = UnknownStateAlertWidget.showCustomDialog(context, device, 0xFF);
+      future = UnknownStateAlertWidget.showCustomDialog(context, device,
+          currentState: 0xFF);
     }));
 
     await tester.tap(find.text('X'));
@@ -144,7 +148,8 @@ void main() {
     SharedPlatform.overridePlatform = null;
 
     await tester.pumpWidget(buildTestAppForWidgets((final context) {
-      future = UnknownStateAlertWidget.showCustomDialog(context, device, 0xFF);
+      future = UnknownStateAlertWidget.showCustomDialog(context, device,
+          currentState: 0xFF);
     }));
 
     await tester.tap(find.text('X'));
@@ -174,7 +179,8 @@ void main() {
     SharedPlatform.overridePlatform = null;
 
     await tester.pumpWidget(buildTestAppForWidgets((final context) {
-      future = UnknownStateAlertWidget.showCustomDialog(context, device, 0xFF);
+      future = UnknownStateAlertWidget.showCustomDialog(context, device,
+          currentState: 0xFF);
     }));
 
     await tester.tap(find.text('X'));
@@ -205,7 +211,8 @@ void main() {
     SharedPlatform.overridePlatform = null;
 
     await tester.pumpWidget(buildTestAppForWidgets((final context) {
-      future = UnknownStateAlertWidget.showCustomDialog(context, device, 0xFF);
+      future = UnknownStateAlertWidget.showCustomDialog(context, device,
+          currentState: 0xFF);
     }));
 
     await tester.tap(find.text('X'));
@@ -231,7 +238,8 @@ void main() {
     SharedPlatform.overridePlatform = null;
 
     await tester.pumpWidget(buildTestAppForWidgets((final context) {
-      UnknownStateAlertWidget.showCustomDialog(context, device, 0xFF);
+      UnknownStateAlertWidget.showCustomDialog(context, device,
+          currentState: 0xFF);
     }));
 
     await tester.tap(find.text('X'));
@@ -276,7 +284,8 @@ void main() {
     );
 
     await tester.pumpWidget(buildTestAppForWidgets((final context) {
-      UnknownStateHelpOutAlertWidget.showCustomDialog(context, device, 0xFF);
+      UnknownStateHelpOutAlertWidget.showCustomDialog(context, device,
+          currentState: 0xFF);
     }));
 
     await tester.tap(find.text('X'));
@@ -312,7 +321,8 @@ void main() {
     );
 
     await tester.pumpWidget(buildTestAppForWidgets((final context) {
-      UnknownStateHelpOutAlertWidget.showCustomDialog(context, device, 0xFF);
+      UnknownStateHelpOutAlertWidget.showCustomDialog(context, device,
+          currentState: 0xFF);
     }));
 
     await tester.tap(find.text('X'));
@@ -352,7 +362,8 @@ void main() {
     );
 
     await tester.pumpWidget(buildTestAppForWidgets((final context) {
-      UnknownStateHelpOutAlertWidget.showCustomDialog(context, device, 0xFF);
+      UnknownStateHelpOutAlertWidget.showCustomDialog(context, device,
+          currentState: 0xFF);
     }));
 
     await tester.tap(find.text('X'));


### PR DESCRIPTION
- `LighthouseDevice`'s are now not stateful by default. Meaning that a device doesn't have to be able to read the current state from the device. This is to add a better interface for Vive Base station devices.
- Converted `LighthousePowerState` to an enum.
- Updated tests to reflect these changes.