### PR TITLE
The new flutter reactive ble library requires a lot more time to connect to devices.

### DIFF
--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -317,7 +317,9 @@ class _ScanDevicesPage extends State<ScanDevicesPage>
               final listLength = groups.length + notGroupedDevices.length;
               final theming = Theming.of(context);
 
-              final Widget body = (devices.isEmpty && updates > 2)
+              final Widget body = (groups.isEmpty &&
+                      devices.isEmpty &&
+                      updates > 2)
                   ? StreamBuilder<bool>(
                       stream: LighthouseProvider.instance.isScanning,
                       initialData: true,

--- a/lighthouse_provider/lighthouse_back_ends/flutter_reactive_ble_back_end/lib/src/ble/flutter_reactive_ble_device.dart
+++ b/lighthouse_provider/lighthouse_back_ends/flutter_reactive_ble_back_end/lib/src/ble/flutter_reactive_ble_device.dart
@@ -16,7 +16,7 @@ class FlutterReactiveBleBluetoothDevice extends LHBluetoothDevice {
   final LHDeviceIdentifier id;
 
   @override
-  Future<void> connect({final Duration? timeout}) async {
+  Future<void> connect({Duration? timeout}) async {
     final connection = _connectionSubscription;
     _connectionSubscription = null;
     await connection?.cancel();
@@ -38,6 +38,9 @@ class FlutterReactiveBleBluetoothDevice extends LHBluetoothDevice {
         return;
       });
     } else {
+      if (timeout < FlutterReactiveBleBackEnd._minimumConnectDuration) {
+        timeout = FlutterReactiveBleBackEnd._minimumConnectDuration;
+      }
       return _connectionSubject.stream
           .firstWhere((element) =>
               element.connectionState == DeviceConnectionState.connected)

--- a/lighthouse_provider/lighthouse_back_ends/flutter_reactive_ble_back_end/lib/src/flutter_reactive_ble_io.dart
+++ b/lighthouse_provider/lighthouse_back_ends/flutter_reactive_ble_back_end/lib/src/flutter_reactive_ble_io.dart
@@ -23,6 +23,8 @@ class FlutterReactiveBleBackEnd extends BLELighthouseBackEnd {
     return _instance ??= FlutterReactiveBleBackEnd._();
   }
 
+  static const Duration _minimumConnectDuration = Duration(seconds: 15);
+
   // Some state variables.
   final Mutex _devicesMutex = Mutex();
   final Set<LHDeviceIdentifier> _connectingDevices = {};


### PR DESCRIPTION

- Added a minimum timeout to the connection state.
- Don' show troubleshooting page if the user has groups.