### PR TITLE
Small fixes and debug mode

### DIFF
--- a/lib/data/local/app_route_settings.dart
+++ b/lib/data/local/app_route_settings.dart
@@ -1,0 +1,19 @@
+import 'package:lighthouse_pm/bloc.dart';
+import 'package:rxdart/rxdart.dart';
+
+class AppRouteSettings {
+  const AppRouteSettings(final bool? debugEnabled)
+      : debugEnabled = debugEnabled ?? false;
+
+  const AppRouteSettings.withDefaults() : this(null);
+
+  final bool debugEnabled;
+
+  static Stream<AppRouteSettings> getStream(final LighthousePMBloc bloc) {
+    return MergeStream(
+            [Stream.value(false), bloc.settings.getDebugModeEnabledStream()])
+        .map((final enabled) {
+      return AppRouteSettings(enabled);
+    });
+  }
+}

--- a/lib/data/local/theme_data_and_app_style_stream.dart
+++ b/lib/data/local/theme_data_and_app_style_stream.dart
@@ -12,6 +12,8 @@ class ThemeDataAndAppStyleStream {
         style = style ?? AppStyle.material,
         alwaysShowScrollbar = alwaysShowScrollbar ?? false;
 
+  const ThemeDataAndAppStyleStream.withDefaults() : this(null, null, null);
+
   final ThemeMode themeMode;
   final AppStyle style;
   final bool alwaysShowScrollbar;

--- a/lib/lighthouse_provider/lighthouse_provider_start.dart
+++ b/lib/lighthouse_provider/lighthouse_provider_start.dart
@@ -1,11 +1,16 @@
+import 'dart:async';
+
 import 'package:bluez_back_end/bluez_back_end.dart';
+import 'package:fake_back_end/fake_back_end.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_blue_plus_back_end/flutter_blue_plus_back_end.dart';
 import 'package:flutter_web_bluetooth_back_end/flutter_web_bluetooth_back_end.dart';
+import 'package:lighthouse_back_end/lighthouse_back_end.dart';
 import 'package:lighthouse_logger/lighthouse_logger.dart';
 import 'package:lighthouse_pm/bloc.dart';
 import 'package:lighthouse_pm/bloc/lighthouse_v2_bloc.dart';
 import 'package:lighthouse_pm/bloc/vive_base_station_bloc.dart';
+import 'package:lighthouse_pm/data/helper_structures/lighthouse_providers.dart';
 import 'package:lighthouse_pm/lighthouse_provider/widgets/vive_base_station_extra_info_alert_widget.dart';
 import 'package:lighthouse_pm/platform_specific/mobile/android/android_launcher_shortcut/android_launcher_shortcut.dart';
 import 'package:lighthouse_provider/lighthouse_provider.dart';
@@ -18,7 +23,10 @@ import 'package:shared_platform/shared_platform.dart';
 class LighthouseProviderStart {
   LighthouseProviderStart._();
 
-  static BehaviorSubject<List<LogRecord>>? logs;
+  static BehaviorSubject<List<LogRecord>> logs =
+      BehaviorSubject.seeded(<LogRecord>[]);
+
+  static StreamSubscription? loggerSubscription;
 
   static void loadLibrary() {
     if (SharedPlatform.isIOS || SharedPlatform.isAndroid) {
@@ -26,17 +34,14 @@ class LighthouseProviderStart {
           .addBackEnd(FlutterBluePlusLighthouseBackEnd.instance);
     }
     if (SharedPlatform.isWeb) {
-      // LighthouseProvider.instance
-      //     .addBackEnd(FlutterWebBluetoothBackEnd.instance);
+      LighthouseProvider.instance
+          .addBackEnd(FlutterWebBluetoothBackEnd.instance);
     }
     if (SharedPlatform.isLinux) {
-      // LighthouseProvider.instance.addBackEnd(BlueZBackEnd.instance);
+      LighthouseProvider.instance.addBackEnd(BlueZBackEnd.instance);
     }
 
     assert(() {
-
-      logs = BehaviorSubject.seeded(<LogRecord>[]);
-
       lighthouseLogger.onRecord.listen((final record) {
         debugPrint("${record.loggerName}|${record.time}: ${record.message}");
         if (record.error != null) {
@@ -45,34 +50,20 @@ class LighthouseProviderStart {
         if (record.stackTrace != null) {
           debugPrint("Trace: ${record.stackTrace.toString()}");
         }
-
-        logs!.add([
-          ...logs!.value,
-          record
-        ]);
       });
-      // Add this back if you need to test for devices you don't own.
-      // you'll also need to
-      // import 'package:lighthouse_pm/lighthouse_back_ends/fake/fake_back_end.dart';
 
-      // LighthouseProvider.instance.addBackEnd(FakeBLEBackEnd.instance);
       return true;
     }());
-
-    LighthouseProvider.instance
-        .addProvider(LighthouseV2DeviceProvider.instance);
-    // LighthouseProvider.instance
-    //     .addProvider(ViveBaseStationDeviceProvider.instance);
   }
 
   static void setupPersistence(final LighthousePMBloc bloc) {
-    // ViveBaseStationDeviceProvider.instance
-    //     .setPersistence(ViveBaseStationBloc(bloc));
+    ViveBaseStationDeviceProvider.instance
+        .setPersistence(ViveBaseStationBloc(bloc));
     LighthouseV2DeviceProvider.instance.setPersistence(LighthouseV2Bloc(bloc));
   }
 
   static void setupCallbacks() {
-    /*ViveBaseStationDeviceProvider.instance
+    ViveBaseStationDeviceProvider.instance
         .setRequestPairIdCallback<BuildContext>(
             (final BuildContext? context, final pairIdHint) async {
       assert(context != null, "Context should not be null");
@@ -83,7 +74,7 @@ class LighthouseProviderStart {
       }
       return ViveBaseStationExtraInfoAlertWidget.showCustomDialog(
           context, pairIdHint);
-    });*/
+    });
 
     LighthouseV2DeviceProvider.instance
         .setCreateShortcutCallback((final mac, final name) async {
@@ -92,5 +83,48 @@ class LighthouseProviderStart {
             .requestShortcutLighthouse(mac, name);
       }
     });
+  }
+
+  ///
+  /// Start listening to certain settings to help set everything up.
+  ///
+  static void startBlocListening(final LighthousePMBloc bloc) {
+    bloc.settings.getDebugModeEnabledStream().listen((final enabled) {
+      if (enabled) {
+        loggerSubscription = lighthouseLogger.onRecord.listen((final record) {
+          logs.add([...logs.value, record]);
+        });
+      } else {
+        logs.add([]);
+        final subscription = loggerSubscription;
+        loggerSubscription = null;
+        subscription?.cancel();
+      }
+    });
+
+    bloc.settings.getUseFakeBackEndStream().listen((final useFake) {
+      if (useFake) {
+        LighthouseProvider.instance.addBackEnd(FakeBLEBackEnd.instance);
+      } else {
+        LighthouseProvider.instance.removeBackEnd(FakeBLEBackEnd.instance);
+      }
+    });
+
+    bloc.settings.getEnabledDeviceProvidersStream().listen((final providers) {
+      _addOrRemoveProvider(providers, LighthouseV2DeviceProvider.instance);
+      _addOrRemoveProvider(providers, ViveBaseStationDeviceProvider.instance);
+    });
+  }
+
+  static void _addOrRemoveProvider(final List<LighthouseProviders> providers,
+      final DeviceProvider provider) {
+    final contains =
+        providers.indexWhere((final element) => element.provider == provider) >=
+            0;
+    if (contains) {
+      LighthouseProvider.instance.addProvider(provider);
+    } else {
+      LighthouseProvider.instance.removeProvider(provider);
+    }
   }
 }

--- a/lib/lighthouse_provider/lighthouse_provider_start.dart
+++ b/lib/lighthouse_provider/lighthouse_provider_start.dart
@@ -11,10 +11,14 @@ import 'package:lighthouse_pm/platform_specific/mobile/android/android_launcher_
 import 'package:lighthouse_provider/lighthouse_provider.dart';
 import 'package:lighthouse_providers/lighthouse_v2_device_provider.dart';
 import 'package:lighthouse_providers/vive_base_station_device_provider.dart';
+import 'package:logging/logging.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:shared_platform/shared_platform.dart';
 
 class LighthouseProviderStart {
   LighthouseProviderStart._();
+
+  static BehaviorSubject<List<LogRecord>>? logs;
 
   static void loadLibrary() {
     if (SharedPlatform.isIOS || SharedPlatform.isAndroid) {
@@ -22,14 +26,17 @@ class LighthouseProviderStart {
           .addBackEnd(FlutterBluePlusLighthouseBackEnd.instance);
     }
     if (SharedPlatform.isWeb) {
-      LighthouseProvider.instance
-          .addBackEnd(FlutterWebBluetoothBackEnd.instance);
+      // LighthouseProvider.instance
+      //     .addBackEnd(FlutterWebBluetoothBackEnd.instance);
     }
     if (SharedPlatform.isLinux) {
-      LighthouseProvider.instance.addBackEnd(BlueZBackEnd.instance);
+      // LighthouseProvider.instance.addBackEnd(BlueZBackEnd.instance);
     }
 
     assert(() {
+
+      logs = BehaviorSubject.seeded(<LogRecord>[]);
+
       lighthouseLogger.onRecord.listen((final record) {
         debugPrint("${record.loggerName}|${record.time}: ${record.message}");
         if (record.error != null) {
@@ -38,6 +45,11 @@ class LighthouseProviderStart {
         if (record.stackTrace != null) {
           debugPrint("Trace: ${record.stackTrace.toString()}");
         }
+
+        logs!.add([
+          ...logs!.value,
+          record
+        ]);
       });
       // Add this back if you need to test for devices you don't own.
       // you'll also need to
@@ -49,18 +61,18 @@ class LighthouseProviderStart {
 
     LighthouseProvider.instance
         .addProvider(LighthouseV2DeviceProvider.instance);
-    LighthouseProvider.instance
-        .addProvider(ViveBaseStationDeviceProvider.instance);
+    // LighthouseProvider.instance
+    //     .addProvider(ViveBaseStationDeviceProvider.instance);
   }
 
   static void setupPersistence(final LighthousePMBloc bloc) {
-    ViveBaseStationDeviceProvider.instance
-        .setPersistence(ViveBaseStationBloc(bloc));
+    // ViveBaseStationDeviceProvider.instance
+    //     .setPersistence(ViveBaseStationBloc(bloc));
     LighthouseV2DeviceProvider.instance.setPersistence(LighthouseV2Bloc(bloc));
   }
 
   static void setupCallbacks() {
-    ViveBaseStationDeviceProvider.instance
+    /*ViveBaseStationDeviceProvider.instance
         .setRequestPairIdCallback<BuildContext>(
             (final BuildContext? context, final pairIdHint) async {
       assert(context != null, "Context should not be null");
@@ -71,7 +83,7 @@ class LighthouseProviderStart {
       }
       return ViveBaseStationExtraInfoAlertWidget.showCustomDialog(
           context, pairIdHint);
-    });
+    });*/
 
     LighthouseV2DeviceProvider.instance
         .setCreateShortcutCallback((final mac, final name) async {

--- a/lib/lighthouse_provider/widgets/lighthouse_metadata_page.dart
+++ b/lib/lighthouse_provider/widgets/lighthouse_metadata_page.dart
@@ -43,7 +43,7 @@ class LighthouseMetadataState extends State<LighthouseMetadataPage> {
 
   List<Widget> _generateBody() {
     final Map<String, String?> map = {};
-    map["Device type"] = "${widget.device.runtimeType}";
+    map["Device type"] = widget.device.deviceType;
     map["Name"] = widget.device.name;
     map["Firmware version"] = widget.device.firmwareVersion;
     map.addAll(widget.device.otherMetadata);

--- a/lib/lighthouse_provider/widgets/unknown_state_alert_widget.dart
+++ b/lib/lighthouse_provider/widgets/unknown_state_alert_widget.dart
@@ -100,7 +100,7 @@ class UnknownStateHelpOutAlertWidget extends StatelessWidget {
 
   String _getClipboardString(final String version) {
     var output = 'App version: $version\n'
-        'Device type: ${device.runtimeType}\n'
+        'Device type: ${device.deviceType}\n'
         'Firmware version: ${device.firmwareVersion}\n';
     if (currentState != null) {
       output +=
@@ -155,7 +155,7 @@ class UnknownStateHelpOutAlertWidget extends StatelessWidget {
             ),
             TextSpan(
               style: theming.bodyTextBold,
-              text: '${device.runtimeType}\n',
+              text: '${device.deviceType}\n',
               recognizer: recognizer,
             ),
             TextSpan(

--- a/lib/lighthouse_provider/widgets/vive_base_station_extra_info_alert_widget.dart
+++ b/lib/lighthouse_provider/widgets/vive_base_station_extra_info_alert_widget.dart
@@ -117,7 +117,7 @@ class _ViveBaseStationExtraInfoAlertState
                   }
                 }
               }
-              if (mounted) {
+              if (context.mounted) {
                 Navigator.pop(context, text);
               }
             }

--- a/lib/lighthouse_provider/widgets/widget_for_extension.dart
+++ b/lib/lighthouse_provider/widgets/widget_for_extension.dart
@@ -24,7 +24,7 @@ Widget getWidgetFromDeviceExtension(
     return const Text('ID');
   }
 
-  return Text(extension.runtimeType.toString());
+  return Text(extension.extensionName);
 }
 
 Color getButtonColorFromDeviceExtension(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:lighthouse_pm/data/database.dart';
+import 'package:lighthouse_pm/data/local/app_route_settings.dart';
 import 'package:lighthouse_pm/data/local/app_style.dart';
 import 'package:lighthouse_pm/data/local/theme_data_and_app_style_stream.dart';
 import 'package:lighthouse_pm/lighthouse_provider/lighthouse_provider_start.dart';
@@ -19,7 +20,9 @@ import 'package:lighthouse_pm/platform_specific/mobile/android/android_launcher_
 import 'package:lighthouse_pm/platform_specific/mobile/in_app_purchases.dart';
 import 'package:lighthouse_pm/platform_specific/shared/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:shared_platform/shared_platform.dart';
+import 'package:tuple/tuple.dart';
 
 import 'bloc.dart';
 import 'build_options.dart';
@@ -52,6 +55,7 @@ class MainApp extends StatelessWidget {
     LighthouseProviderStart.loadLibrary();
     LighthouseProviderStart.setupPersistence(mainBloc);
     LighthouseProviderStart.setupCallbacks();
+    LighthouseProviderStart.startBlocListening(mainBloc);
 
     if (BuildOptions.includeGooglePlayInAppPurchases) {
       InAppPurchases.instance
@@ -71,19 +75,23 @@ class LighthousePMApp extends StatelessWidget with WithBlocStateless {
   @override
   Widget build(final BuildContext context) {
     return DynamicColorBuilder(builder: (final lightColor, final darkColor) {
-      return StreamBuilder<ThemeDataAndAppStyleStream>(
-        stream:
-            ThemeDataAndAppStyleStream.getStream(blocWithoutListen(context)),
-        initialData: const ThemeDataAndAppStyleStream(null, null, null),
+      return StreamBuilder<
+          Tuple2<AppRouteSettings, ThemeDataAndAppStyleStream>>(
+        stream: _getMainStream(blocWithoutListen(context)),
+        initialData: const Tuple2(AppRouteSettings.withDefaults(),
+            ThemeDataAndAppStyleStream.withDefaults()),
         builder: (final BuildContext context,
-            final AsyncSnapshot<ThemeDataAndAppStyleStream>
+            final AsyncSnapshot<
+                    Tuple2<AppRouteSettings, ThemeDataAndAppStyleStream>>
                 themeAndStyleSnapshot) {
           final data = themeAndStyleSnapshot.data;
-          final themeMode = data?.themeMode ?? ThemeMode.system;
-          final useDynamicColors = data?.style == AppStyle.materialDynamic;
+          final themeMode = data?.item2.themeMode ?? ThemeMode.system;
+          final useDynamicColors =
+              data?.item2.style == AppStyle.materialDynamic;
           final dynamicColorsLight = lightColor ?? lightColorScheme;
           final dynamicColorsDark = darkColor ?? darkColorScheme;
-          final scrollbarDesktop = data?.alwaysShowScrollbar ?? false;
+          final scrollbarDesktop = data?.item2.alwaysShowScrollbar ?? false;
+          final debugModeEnabled = data?.item1.debugEnabled ?? false;
 
           final scrollbarTheme = ScrollbarThemeData(
             thumbVisibility: MaterialStateProperty.all(scrollbarDesktop),
@@ -122,15 +130,18 @@ class LighthousePMApp extends StatelessWidget with WithBlocStateless {
 
               routes.addAll(SettingsPage.getSubPages('/settings'));
 
+              if (debugModeEnabled) {
+                routes['/material'] =
+                    (final context) => const MaterialTestPage();
+                routes['/log'] = (final context) => const LogPage();
+              }
+
               if (!kReleaseMode) {
                 routes.addAll(<String, PageBuilder>{
                   '/databaseTest': (final context) => DatabaseTestPage()
                 });
                 routes.addAll(DatabaseTestPage.getSubPages('/databaseTest'));
-                routes['/material'] =
-                    (final context) => const MaterialTestPage();
                 routes['/404'] = (final context) => const NotFoundPage();
-                routes['/log'] = (final context) => const LogPage();
               }
 
               if (SharedPlatform.isWeb || !kReleaseMode) {
@@ -163,4 +174,13 @@ BasePage _createShortcutDebugPage(final BuildContext context) {
         ShortcutHandle(ShortcutTypes.macType, "00:00:00:00:00:00"));
   }
   return const SimpleBasePage(Text('This should not be here.'));
+}
+
+Stream<Tuple2<AppRouteSettings, ThemeDataAndAppStyleStream>> _getMainStream(
+    final LighthousePMBloc bloc) {
+  return Rx.combineLatest2(
+      AppRouteSettings.getStream(bloc),
+      ThemeDataAndAppStyleStream.getStream(bloc),
+      (final routeSettings, final themeDataAndAppStyle) =>
+          Tuple2(routeSettings, themeDataAndAppStyle));
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:lighthouse_pm/lighthouse_provider/lighthouse_provider_start.dart
 import 'package:lighthouse_pm/pages/base_page.dart';
 import 'package:lighthouse_pm/pages/database_test_page.dart';
 import 'package:lighthouse_pm/pages/help_page.dart';
+import 'package:lighthouse_pm/pages/log_page.dart';
 import 'package:lighthouse_pm/pages/main_page.dart';
 import 'package:lighthouse_pm/pages/not_found_page.dart';
 import 'package:lighthouse_pm/pages/settings_page.dart';
@@ -129,6 +130,7 @@ class LighthousePMApp extends StatelessWidget with WithBlocStateless {
                 routes['/material'] =
                     (final context) => const MaterialTestPage();
                 routes['/404'] = (final context) => const NotFoundPage();
+                routes['/log'] = (final context) => const LogPage();
               }
 
               if (SharedPlatform.isWeb || !kReleaseMode) {

--- a/lib/pages/database/settings_dao_page.dart
+++ b/lib/pages/database/settings_dao_page.dart
@@ -90,9 +90,10 @@ class _SimpleSettingConverter extends DaoTableDataConverter<SimpleSetting> {
         }
         final themeMode = ThemeMode.values[value];
         return themeMode.toString();
+      case SettingsIds.debugMode:
       case SettingsIds.shortcutEnabledId:
-        return convertToBoolean(data);
       case SettingsIds.groupShowOfflineWarningId:
+      case SettingsIds.useFakeBackEnd:
         return convertToBoolean(data);
       case SettingsIds.updateIntervalId:
         if (data == null) {

--- a/lib/pages/log_page.dart
+++ b/lib/pages/log_page.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:lighthouse_pm/lighthouse_provider/lighthouse_provider_start.dart';
+import 'package:lighthouse_pm/widgets/content_container_widget.dart';
+import 'package:logging/logging.dart';
+import 'package:toast/toast.dart';
+
+import 'base_page.dart';
+
+class LogPage extends BasePage {
+  const LogPage({super.key});
+
+  @override
+  Widget buildPage(final BuildContext context) {
+    return _LogPageContent();
+  }
+}
+
+class _LogPageContent extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() {
+    return _LogPageContentState();
+  }
+}
+
+class _LogPageContentState extends State<_LogPageContent> {
+  @override
+  Widget build(final BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: const Text('Activity log'),
+          actions: [
+            IconButton(
+                onPressed: () {
+                  setState(() {
+                    LighthouseProviderStart.logs!.add([]);
+                  });
+                },
+                icon: const Icon(Icons.delete_forever)),
+            IconButton(
+                onPressed: () {
+                  final clipboard = LighthouseProviderStart.logs!.value.fold("",
+                      (final previousValue, final element) {
+                    return "$previousValue\n${element.time}: ${element.level.name}: ${element.message}";
+                  });
+                  Clipboard.setData(ClipboardData(text: clipboard))
+                      .then((final _) {
+                    Toast.show("Copied to clipboard");
+                  });
+                },
+                icon: const Icon(Icons.copy)),
+          ],
+        ),
+        body: StreamBuilder<List<LogRecord>>(
+          initialData: const [],
+          stream: LighthouseProviderStart.logs!,
+          builder: (final context, final snapshot) {
+            final logs = snapshot.requireData;
+
+            return ContentContainerListView.builder(
+                itemCount: logs.length,
+                itemBuilder: (final BuildContext context, final int index) {
+                  if (index >= logs.length) {
+                    return null;
+                  } else if (index < 0) {
+                    return null;
+                  }
+                  final item = logs[index];
+
+                  return ListTile(
+                    title: Text(
+                        "${item.time}: ${item.level.name}: ${item.message}"),
+                  );
+                });
+          },
+        ));
+  }
+}

--- a/lib/pages/log_page.dart
+++ b/lib/pages/log_page.dart
@@ -33,13 +33,13 @@ class _LogPageContentState extends State<_LogPageContent> {
             IconButton(
                 onPressed: () {
                   setState(() {
-                    LighthouseProviderStart.logs!.add([]);
+                    LighthouseProviderStart.logs.add([]);
                   });
                 },
                 icon: const Icon(Icons.delete_forever)),
             IconButton(
                 onPressed: () {
-                  final clipboard = LighthouseProviderStart.logs!.value.fold("",
+                  final clipboard = LighthouseProviderStart.logs.value.fold("",
                       (final previousValue, final element) {
                     return "$previousValue\n${element.time}: ${element.level.name}: ${element.message}";
                   });
@@ -53,7 +53,7 @@ class _LogPageContentState extends State<_LogPageContent> {
         ),
         body: StreamBuilder<List<LogRecord>>(
           initialData: const [],
-          stream: LighthouseProviderStart.logs!,
+          stream: LighthouseProviderStart.logs,
           builder: (final context, final snapshot) {
             final logs = snapshot.requireData;
 

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -700,7 +700,7 @@ class _ScanDevicesPage extends State<ScanDevicesPage>
     for (final device in devicesToBeInAGroup) {
       String? channel = device.otherMetadata['Channel'];
       if (channel != null) {
-        channel = '${device.runtimeType.toString()}+$channel';
+        channel = '${device.deviceType}+$channel';
         if (!knownChannels.contains(channel)) {
           knownChannels.add(channel);
         } else {
@@ -716,7 +716,7 @@ class _ScanDevicesPage extends State<ScanDevicesPage>
   bool _allSameDeviceType(final List<LighthouseDevice> devicesToBeInAGroup) {
     final foundTypes = <String>{};
     for (final device in devicesToBeInAGroup) {
-      foundTypes.add(device.runtimeType.toString());
+      foundTypes.add(device.deviceType);
       if (foundTypes.length > 1) {
         return false;
       }
@@ -782,7 +782,8 @@ class _ScanDevicesPage extends State<ScanDevicesPage>
         startScanWithCheck(Duration(seconds: widget.settings.scanDuration),
             updateInterval: Duration(seconds: widget.settings.updateInterval),
             failMessage:
-                "Could not start scan because the permission has not been granted on resume.");
+                "Could not start scan because the permission has not been granted on resume.",
+            clean: false);
         break;
       case AppLifecycleState.inactive:
       case AppLifecycleState.detached:

--- a/lib/widgets/content_container_widget.dart
+++ b/lib/widgets/content_container_widget.dart
@@ -83,7 +83,7 @@ class ContentContainerListView extends StatelessWidget {
     final int? itemCount,
     final double maxSize = ContentContainerWidget.defaultMaxSize,
     final double contentSize = ContentContainerWidget.defaultContentSize,
-    required final IndexedWidgetBuilder itemBuilder,
+    required final NullableIndexedWidgetBuilder itemBuilder,
   }) {
     return Stack(
       children: [
@@ -99,9 +99,12 @@ class ContentContainerListView extends StatelessWidget {
           return ListView.builder(
             controller: controller,
             itemBuilder: (final BuildContext context, final int index) {
-              final Widget content = itemBuilder(context, index);
+              final Widget? content = itemBuilder(context, index);
               return ContentContainerWidget(
                 builder: (final BuildContext context) {
+                  if (content == null) {
+                    return Container();
+                  }
                   return content;
                 },
                 addMaterial: false,

--- a/lib/widgets/main_page_drawer.dart
+++ b/lib/widgets/main_page_drawer.dart
@@ -82,7 +82,19 @@ class MainPageDrawer extends StatelessWidget with ScanningMixin {
                 failMessage:
                     "Could not start scan because permission has not been granted. On navigator pop");
           },
-        )
+        ),
+        ListTile(
+            leading: const Icon(CommunityMaterialIcons.pulse),
+            title: const Text('Activity log'),
+            onTap: () async {
+              Navigator.pop(context);
+              cleanUp();
+              await Navigator.pushNamed(context, '/log');
+              startScanWithCheck(scanDuration,
+                  updateInterval: updateInterval,
+                  failMessage:
+                      "Could not start scan because permission has not been granted. On navigator pop");
+            })
       ]
     ];
 

--- a/lib/widgets/main_page_drawer.dart
+++ b/lib/widgets/main_page_drawer.dart
@@ -2,9 +2,12 @@ import 'package:community_material_icon/community_material_icon.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:lighthouse_pm/bloc.dart';
+import 'package:lighthouse_pm/theming.dart';
 import 'package:lighthouse_pm/widgets/scanning_mixin.dart';
 
-class MainPageDrawer extends StatelessWidget with ScanningMixin {
+class MainPageDrawer extends StatelessWidget
+    with ScanningMixin, WithBlocStateless {
   const MainPageDrawer(this.scanDuration, this.updateInterval, {super.key});
 
   final Duration scanDuration;
@@ -12,95 +15,111 @@ class MainPageDrawer extends StatelessWidget with ScanningMixin {
 
   @override
   Widget build(final BuildContext context) {
-    final children = <Widget>[
-      DrawerHeader(
-          decoration: const BoxDecoration(
-              image: DecorationImage(
-                  image: AssetImage('assets/images/drawer-image.png'),
-                  fit: BoxFit.cover)),
-          child: SvgPicture.asset('assets/images/app-icon.svg')),
-      ListTile(
-          leading: const Icon(Icons.report),
-          title: const Text('Troubleshooting'),
-          onTap: () async {
-            Navigator.pop(context);
-            cleanUp();
-            await Navigator.pushNamed(context, '/troubleshooting');
-            startScanWithCheck(scanDuration,
-                updateInterval: updateInterval,
-                failMessage:
-                    "Could not start scan because permission has not been granted. On navigator pop");
-          }),
-      ListTile(
-        leading: const Icon(Icons.info),
-        title: const Text('Help'),
-        onTap: () async {
-          Navigator.pop(context);
-          cleanUp();
-          await Navigator.pushNamed(context, '/help');
-          startScanWithCheck(scanDuration,
-              updateInterval: updateInterval,
-              failMessage:
-                  "Could not start scan because permission has not been granted. On navigator pop");
-        },
-      ),
-      ListTile(
-        leading: const Icon(Icons.settings),
-        title: const Text('Settings'),
-        onTap: () async {
-          Navigator.pop(context);
-          cleanUp();
-          await Navigator.pushNamed(context, '/settings');
-          startScanWithCheck(scanDuration,
-              updateInterval: updateInterval,
-              failMessage:
-                  "Could not start scan because permission has not been granted. On navigator pop");
-        },
-      ),
-      if (!kReleaseMode) ...[
-        ListTile(
-            leading: const Icon(CommunityMaterialIcons.database),
-            title: const Text('Database test'),
-            onTap: () async {
-              Navigator.pop(context);
-              cleanUp();
-              await Navigator.pushNamed(context, '/databaseTest');
-              startScanWithCheck(scanDuration,
-                  updateInterval: updateInterval,
-                  failMessage:
-                      "Could not start scan because permission has not been granted. On navigator pop");
-            }),
-        ListTile(
-          leading: const Icon(CommunityMaterialIcons.material_design),
-          title: const Text('Material test page'),
-          onTap: () async {
-            Navigator.pop(context);
-            cleanUp();
-            await Navigator.pushNamed(context, '/material');
-            startScanWithCheck(scanDuration,
-                updateInterval: updateInterval,
-                failMessage:
-                    "Could not start scan because permission has not been granted. On navigator pop");
-          },
-        ),
-        ListTile(
-            leading: const Icon(CommunityMaterialIcons.pulse),
-            title: const Text('Activity log'),
-            onTap: () async {
-              Navigator.pop(context);
-              cleanUp();
-              await Navigator.pushNamed(context, '/log');
-              startScanWithCheck(scanDuration,
-                  updateInterval: updateInterval,
-                  failMessage:
-                      "Could not start scan because permission has not been granted. On navigator pop");
-            })
-      ]
-    ];
+    return StreamBuilder(
+        stream: blocWithoutListen(context).settings.getDebugModeEnabledStream(),
+        initialData: false,
+        builder: (final context, final snapshot) {
+          final theming = Theming.of(context);
+          final headTheme =
+              theming.titleLarge?.copyWith(fontWeight: FontWeight.bold);
 
-    return Drawer(
-        child: ListView(
-      children: children,
-    ));
+          final children = <Widget>[
+            DrawerHeader(
+                decoration: const BoxDecoration(
+                    image: DecorationImage(
+                        image: AssetImage('assets/images/drawer-image.png'),
+                        fit: BoxFit.cover)),
+                child: SvgPicture.asset('assets/images/app-icon.svg')),
+            ListTile(
+                leading: const Icon(Icons.report),
+                title: const Text('Troubleshooting'),
+                onTap: () async {
+                  Navigator.pop(context);
+                  cleanUp();
+                  await Navigator.pushNamed(context, '/troubleshooting');
+                  startScanWithCheck(scanDuration,
+                      updateInterval: updateInterval,
+                      failMessage:
+                          "Could not start scan because permission has not been granted. On navigator pop");
+                }),
+            ListTile(
+              leading: const Icon(Icons.info),
+              title: const Text('Help'),
+              onTap: () async {
+                Navigator.pop(context);
+                cleanUp();
+                await Navigator.pushNamed(context, '/help');
+                startScanWithCheck(scanDuration,
+                    updateInterval: updateInterval,
+                    failMessage:
+                        "Could not start scan because permission has not been granted. On navigator pop");
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.settings),
+              title: const Text('Settings'),
+              onTap: () async {
+                Navigator.pop(context);
+                cleanUp();
+                await Navigator.pushNamed(context, '/settings');
+                startScanWithCheck(scanDuration,
+                    updateInterval: updateInterval,
+                    failMessage:
+                        "Could not start scan because permission has not been granted. On navigator pop");
+              },
+            ),
+            if (!kReleaseMode || (snapshot.data ?? false)) ...[
+              ListTile(
+                title: Text('debug', style: headTheme),
+              ),
+            ],
+            if (snapshot.data ?? false) ...[
+              ListTile(
+                leading: const Icon(CommunityMaterialIcons.material_design),
+                title: const Text('Material test page'),
+                onTap: () async {
+                  Navigator.pop(context);
+                  cleanUp();
+                  await Navigator.pushNamed(context, '/material');
+                  startScanWithCheck(scanDuration,
+                      updateInterval: updateInterval,
+                      failMessage:
+                          "Could not start scan because permission has not been granted. On navigator pop");
+                },
+              ),
+              ListTile(
+                  leading: const Icon(CommunityMaterialIcons.pulse),
+                  title: const Text('Activity log'),
+                  onTap: () async {
+                    Navigator.pop(context);
+                    cleanUp();
+                    await Navigator.pushNamed(context, '/log');
+                    startScanWithCheck(scanDuration,
+                        updateInterval: updateInterval,
+                        failMessage:
+                            "Could not start scan because permission has not been granted. On navigator pop");
+                  }),
+            ],
+            if (!kReleaseMode) ...[
+              ListTile(
+                  leading: const Icon(CommunityMaterialIcons.database),
+                  title: const Text('Database test'),
+                  onTap: () async {
+                    Navigator.pop(context);
+                    cleanUp();
+                    await Navigator.pushNamed(context, '/databaseTest');
+                    startScanWithCheck(scanDuration,
+                        updateInterval: updateInterval,
+                        failMessage:
+                            "Could not start scan because permission has not been granted. On navigator pop");
+                  }),
+            ]
+          ];
+
+          return Drawer(
+              child: ListView(
+            children: children,
+          ));
+        });
   }
 }

--- a/lib/widgets/scanning_mixin.dart
+++ b/lib/widgets/scanning_mixin.dart
@@ -16,10 +16,10 @@ abstract class ScanningMixin {
   }
 
   Future startScan(final Duration scanDuration,
-      {final Duration? updateInterval}) async {
+      {final Duration? updateInterval, final bool clean = true}) async {
     try {
-      await LighthouseProvider.instance
-          .startScan(timeout: scanDuration, updateInterval: updateInterval);
+      await LighthouseProvider.instance.startScan(
+          timeout: scanDuration, updateInterval: updateInterval, clean: clean);
     } catch (e, s) {
       debugPrint(
           "Error trying to start scan! ${e.toString()}\n${s.toString()}");
@@ -27,10 +27,13 @@ abstract class ScanningMixin {
   }
 
   Future startScanWithCheck(final Duration scanDuration,
-      {final Duration? updateInterval, final String failMessage = ""}) async {
+      {final Duration? updateInterval,
+      final String failMessage = "",
+      final bool clean = true}) async {
     if (await BLEPermissionsHelper.hasBLEPermissions() ==
         PermissionStatus.granted) {
-      await startScan(scanDuration, updateInterval: updateInterval);
+      await startScan(scanDuration,
+          updateInterval: updateInterval, clean: clean);
     } else if (failMessage.isNotEmpty && !kReleaseMode) {
       debugPrint(failMessage);
     }

--- a/lighthouse_provider/lighthouse_back_end/example/lighthouse_back_end_example.dart
+++ b/lighthouse_provider/lighthouse_back_end/example/lighthouse_back_end_example.dart
@@ -42,6 +42,9 @@ class ExampleBackEnd extends LighthouseBackEnd {
     await super.startScan(timeout: timeout, updateInterval: updateInterval);
     throw UnsupportedError("Do some start scanning");
   }
+
+  @override
+  String get backendName => 'Example back end';
 }
 
 void main() {

--- a/lighthouse_provider/lighthouse_back_end/lib/lighthouse_back_end.dart
+++ b/lighthouse_provider/lighthouse_back_end/lib/lighthouse_back_end.dart
@@ -86,10 +86,10 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
         'updateLastSeen should have been set by the LighthouseProvider!');
     if (providers.isEmpty) {
       assert(() {
-        throw StateError('No device providers added for $backendName.'
+        throw StateError(' $backendName: No device providers added.'
             ' It\'s still in debug mode so FIX it!');
       }());
-      lighthouseLogger.warning("No device providers added for $backendName, "
+      lighthouseLogger.warning("$backendName: No device providers added, "
           "no scan will be run!");
     }
     this.updateInterval = updateInterval;
@@ -123,7 +123,7 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
   @protected
   Future<LighthouseDevice?> getLighthouseDevice(final D device) async {
     lighthouseLogger
-        .info("Trying to connect to device with name: ${device.name}");
+        .info("${device.name}: Trying to connect");
     for (final provider in providers) {
       if (!provider.nameCheck(device.name)) {
         continue;

--- a/lighthouse_provider/lighthouse_back_end/lib/lighthouse_back_end.dart
+++ b/lighthouse_provider/lighthouse_back_end/lib/lighthouse_back_end.dart
@@ -122,8 +122,7 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
   /// Will return `null` if no device provider could validate the device.
   @protected
   Future<LighthouseDevice?> getLighthouseDevice(final D device) async {
-    lighthouseLogger
-        .info("${device.name}: Trying to connect");
+    lighthouseLogger.info("${device.name}: Trying to connect");
     for (final provider in providers) {
       if (!provider.nameCheck(device.name)) {
         continue;

--- a/lighthouse_provider/lighthouse_back_end/lib/lighthouse_back_end.dart
+++ b/lighthouse_provider/lighthouse_back_end/lib/lighthouse_back_end.dart
@@ -86,10 +86,10 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
         'updateLastSeen should have been set by the LighthouseProvider!');
     if (providers.isEmpty) {
       assert(() {
-        throw StateError('No device providers added for $runtimeType.'
+        throw StateError('No device providers added for $backendName.'
             ' It\'s still in debug mode so FIX it!');
       }());
-      lighthouseLogger.warning("No device providers added for $runtimeType, "
+      lighthouseLogger.warning("No device providers added for $backendName, "
           "no scan will be run!");
     }
     this.updateInterval = updateInterval;
@@ -99,7 +99,7 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
   Future<void> stopScan();
 
   /// Cleanup the any connection artifacts.
-  Future<void> cleanUp() async {}
+  Future<void> cleanUp({final bool onlyDisconnected = false}) async {}
 
   /// Disconnect form any open devices.
   /// If needed a subclass may override this, but be sure to call the super method!
@@ -140,4 +140,6 @@ abstract class LighthouseBackEnd<T extends DeviceProvider<D>,
   /// A stream that updates if the current back end is scanning.
   /// Will return `null` if the back end doesn't support it.
   Stream<bool>? get isScanning => null;
+
+  String get backendName;
 }

--- a/lighthouse_provider/lighthouse_back_end/lib/src/device/ble_device.dart
+++ b/lighthouse_provider/lighthouse_back_end/lib/src/device/ble_device.dart
@@ -69,8 +69,8 @@ abstract class BLEDevice<T> extends LighthouseDevice {
               response = await characteristic.readString();
               break;
             default:
-              lighthouseLogger
-                  .warning("Unsupported type ${defaultCharacteristic.type}");
+              lighthouseLogger.warning(
+                  "${device.name} ($deviceIdentifier): Unsupported type ${defaultCharacteristic.type}");
               break;
           }
           if (response != null) {
@@ -78,6 +78,7 @@ abstract class BLEDevice<T> extends LighthouseDevice {
           }
         } catch (e, s) {
           lighthouseLogger.severe(
+              "${device.name} ($deviceIdentifier): "
               "Unable to get metadata characteristic "
               "\"${defaultCharacteristic.name}\"",
               e,

--- a/lighthouse_provider/lighthouse_back_end/lib/src/device_provider/ble_device_provider.dart
+++ b/lighthouse_provider/lighthouse_back_end/lib/src/device_provider/ble_device_provider.dart
@@ -58,12 +58,14 @@ abstract class BLEDeviceProvider<T> extends DeviceProvider<LHBluetoothDevice> {
       }
       return valid ? bleDevice : null;
     } catch (e, s) {
-      lighthouseLogger.severe("Error with is valid handled: $e\n$s");
+      lighthouseLogger.severe("${device.name} (${device.id}): "
+          "Error with isValid handled: $e\n$s");
       try {
         await bleDevice.disconnect();
       } catch (e, s) {
         lighthouseLogger
-            .severe("Failed to disconnect, maybe already disconnected: $e\n$s");
+            .severe("${device.name} (${device.id}): Failed to disconnect, "
+                "maybe already disconnected: $e\n$s");
       }
       return null;
     }
@@ -87,9 +89,9 @@ abstract class BLEDeviceProvider<T> extends DeviceProvider<LHBluetoothDevice> {
         await device.disconnect();
       } catch (e, s) {
         lighthouseLogger.severe(
-            "Could not disconnect device (${device.name}, "
-            "${device.deviceIdentifier.toString()}), maybe the device is "
-            "already disconnected?",
+            "${device.name} (${device.deviceIdentifier}): "
+            "Could not disconnect device, "
+            "maybe the device is already disconnected?",
             e,
             s);
       }

--- a/lighthouse_provider/lighthouse_back_end/lib/src/provider/device_provider.dart
+++ b/lighthouse_provider/lighthouse_back_end/lib/src/provider/device_provider.dart
@@ -47,11 +47,19 @@ abstract class DeviceProvider<D extends LowLevelDevice> {
   ///
   String get namePrefix;
 
+  ///
+  /// The name of this device provider. This name should be unique
+  ///
+  String get providerName;
+
   @override
   bool operator ==(final Object other) {
-    return runtimeType == other.runtimeType;
+    if (other is DeviceProvider) {
+      return providerName == other.providerName;
+    }
+    return false;
   }
 
   @override
-  int get hashCode => runtimeType.hashCode;
+  int get hashCode => providerName.hashCode;
 }

--- a/lighthouse_provider/lighthouse_back_ends/bluez_back_end/lib/src/bluez_back_end_io.dart
+++ b/lighthouse_provider/lighthouse_back_ends/bluez_back_end/lib/src/bluez_back_end_io.dart
@@ -153,8 +153,7 @@ class BlueZBackEnd extends BLELighthouseBackEnd {
           try {
             await _devicesMutex.acquire();
             if (lighthouseDevice == null) {
-              lighthouseLogger.warning(
-                "${device.name} (${device.address}): "
+              lighthouseLogger.warning("${device.name} (${device.address}): "
                   "Found a not valid device!");
             } else {
               _foundDeviceSubject.add(lighthouseDevice);

--- a/lighthouse_provider/lighthouse_back_ends/bluez_back_end/lib/src/bluez_back_end_io.dart
+++ b/lighthouse_provider/lighthouse_back_ends/bluez_back_end/lib/src/bluez_back_end_io.dart
@@ -154,7 +154,8 @@ class BlueZBackEnd extends BLELighthouseBackEnd {
             await _devicesMutex.acquire();
             if (lighthouseDevice == null) {
               lighthouseLogger.warning(
-                  "Found a not valid device! Device id: ${device.address}");
+                "${device.name} (${device.address}): "
+                  "Found a not valid device!");
             } else {
               _foundDeviceSubject.add(lighthouseDevice);
             }

--- a/lighthouse_provider/lighthouse_back_ends/bluez_back_end/lib/src/bluez_back_end_io.dart
+++ b/lighthouse_provider/lighthouse_back_ends/bluez_back_end/lib/src/bluez_back_end_io.dart
@@ -97,7 +97,7 @@ class BlueZBackEnd extends BLELighthouseBackEnd {
   }
 
   @override
-  Future<void> cleanUp() async {
+  Future<void> cleanUp({final bool onlyDisconnected = false}) async {
     _foundDeviceSubject.add(null);
     if (_devicesMutex.isLocked) {
       _devicesMutex.release();
@@ -174,4 +174,7 @@ class BlueZBackEnd extends BLELighthouseBackEnd {
   Future<void> _ensureConnected() async {
     await blueZClient.connect();
   }
+
+  @override
+  String get backendName => "BluezBackEnd";
 }

--- a/lighthouse_provider/lighthouse_back_ends/bluez_back_end/lib/src/bluez_back_end_unsupported.dart
+++ b/lighthouse_provider/lighthouse_back_ends/bluez_back_end/lib/src/bluez_back_end_unsupported.dart
@@ -27,4 +27,7 @@ class BlueZBackEnd extends BLELighthouseBackEnd {
   Future<void> stopScan() {
     throw UnsupportedError("BlueZ not supported for this platform");
   }
+
+  @override
+  String get backendName => "BluezBackEndUnsupported";
 }

--- a/lighthouse_provider/lighthouse_back_ends/fake_back_end/lib/fake_back_end.dart
+++ b/lighthouse_provider/lighthouse_back_ends/fake_back_end/lib/fake_back_end.dart
@@ -75,4 +75,7 @@ class FakeBLEBackEnd extends BLELighthouseBackEnd {
   @override
   Stream<BluetoothAdapterState> get state =>
       Stream.value(BluetoothAdapterState.on);
+
+  @override
+  String get backendName => "FakeBackEnd";
 }

--- a/lighthouse_provider/lighthouse_back_ends/fake_back_end/test/fake_pair_back_end.dart
+++ b/lighthouse_provider/lighthouse_back_ends/fake_back_end/test/fake_pair_back_end.dart
@@ -57,4 +57,7 @@ class FakePairBackEnd extends BLELighthouseBackEnd with PairBackEnd {
     // TODO: implement pairNewDevice
     throw UnimplementedError();
   }
+
+  @override
+  String get backendName => 'Test beck end';
 }

--- a/lighthouse_provider/lighthouse_back_ends/flutter_blue_plus_back_end/lib/src/flutter_blue_plus_back_end_io.dart
+++ b/lighthouse_provider/lighthouse_back_ends/flutter_blue_plus_back_end/lib/src/flutter_blue_plus_back_end_io.dart
@@ -163,7 +163,7 @@ class FlutterBluePlusLighthouseBackEnd extends BLELighthouseBackEnd {
                 await _devicesMutex.acquire();
                 if (lighthouseDevice == null) {
                   lighthouseLogger.warning(
-                    "${scanResult.device.platformName} ($deviceIdentifier): "
+                      "${scanResult.device.platformName} ($deviceIdentifier): "
                       "Found a non valid device!",
                       null,
                       StackTrace.current);

--- a/lighthouse_provider/lighthouse_back_ends/flutter_blue_plus_back_end/lib/src/flutter_blue_plus_back_end_io.dart
+++ b/lighthouse_provider/lighthouse_back_ends/flutter_blue_plus_back_end/lib/src/flutter_blue_plus_back_end_io.dart
@@ -163,8 +163,8 @@ class FlutterBluePlusLighthouseBackEnd extends BLELighthouseBackEnd {
                 await _devicesMutex.acquire();
                 if (lighthouseDevice == null) {
                   lighthouseLogger.warning(
-                      "Found a non valid device! Device id: "
-                      "${scanResult.device.remoteId.toString()}",
+                    "${scanResult.device.platformName} ($deviceIdentifier): "
+                      "Found a non valid device!",
                       null,
                       StackTrace.current);
                   _rejectedDevices.add(deviceIdentifier);

--- a/lighthouse_provider/lighthouse_back_ends/flutter_blue_plus_back_end/lib/src/flutter_blue_plus_back_end_io.dart
+++ b/lighthouse_provider/lighthouse_back_ends/flutter_blue_plus_back_end/lib/src/flutter_blue_plus_back_end_io.dart
@@ -95,7 +95,7 @@ class FlutterBluePlusLighthouseBackEnd extends BLELighthouseBackEnd {
   }
 
   @override
-  Future<void> cleanUp() async {
+  Future<void> cleanUp({final bool onlyDisconnected = false}) async {
     _foundDeviceSubject.add(null);
     _connectingDevices.clear();
     _rejectedDevices.clear();
@@ -210,4 +210,7 @@ class FlutterBluePlusLighthouseBackEnd extends BLELighthouseBackEnd {
             return BluetoothAdapterState.off;
         }
       });
+
+  @override
+  String get backendName => "FlutterBluePlusBackEnd";
 }

--- a/lighthouse_provider/lighthouse_back_ends/flutter_blue_plus_back_end/lib/src/flutter_blue_plus_back_end_unsupported.dart
+++ b/lighthouse_provider/lighthouse_back_ends/flutter_blue_plus_back_end/lib/src/flutter_blue_plus_back_end_unsupported.dart
@@ -29,4 +29,7 @@ class FlutterBluePlusLighthouseBackEnd extends BLELighthouseBackEnd {
     throw UnsupportedError(
         "Flutter blue plus is not supported for this platform");
   }
+
+  @override
+  String get backendName => "FlutterBlueBackEndUnsupported";
 }

--- a/lighthouse_provider/lighthouse_back_ends/flutter_web_bluetooth_back_end/lib/flutter_web_bluetooth_back_end.dart
+++ b/lighthouse_provider/lighthouse_back_ends/flutter_web_bluetooth_back_end/lib/flutter_web_bluetooth_back_end.dart
@@ -64,7 +64,7 @@ class FlutterWebBluetoothBackEnd extends BLELighthouseBackEnd with PairBackEnd {
   }
 
   @override
-  Future<void> cleanUp() async {
+  Future<void> cleanUp({final bool onlyDisconnected = false}) async {
     _foundDeviceSubject.add(null);
   }
 
@@ -176,4 +176,7 @@ class FlutterWebBluetoothBackEnd extends BLELighthouseBackEnd with PairBackEnd {
 
   @override
   Stream<int> numberOfPairedDevices() => _numberOfPairedDevicesSubject.stream;
+
+  @override
+  String get backendName => "FlutterWebBluetoothBackEnd";
 }

--- a/lighthouse_provider/lighthouse_provider/lib/device_extensions/device_extension.dart
+++ b/lighthouse_provider/lighthouse_provider/lib/device_extensions/device_extension.dart
@@ -28,6 +28,8 @@ abstract class DeviceExtension {
   @protected
   StreamEnabledFunction? streamEnabledFunction;
 
+  String get extensionName;
+
   Stream<bool> get enabledStream {
     final enabledFunction = streamEnabledFunction;
     if (enabledFunction != null) {
@@ -39,9 +41,12 @@ abstract class DeviceExtension {
 
   @override
   bool operator ==(final Object other) {
-    return other.runtimeType == runtimeType;
+    if (other is DeviceExtension) {
+      return extensionName == other.extensionName;
+    }
+    return false;
   }
 
   @override
-  int get hashCode => runtimeType.hashCode;
+  int get hashCode => extensionName.hashCode;
 }

--- a/lighthouse_provider/lighthouse_provider/lib/device_extensions/on_extension.dart
+++ b/lighthouse_provider/lighthouse_provider/lib/device_extensions/on_extension.dart
@@ -6,4 +6,7 @@ part of 'device_extension.dart';
 class OnExtension extends StateExtension {
   OnExtension({required super.changeState, required super.powerStateStream})
       : super(toolTip: "On", toState: LighthousePowerState.on);
+
+  @override
+  String get extensionName => "OnExtension";
 }

--- a/lighthouse_provider/lighthouse_provider/lib/device_extensions/shortcut_extension.dart
+++ b/lighthouse_provider/lighthouse_provider/lib/device_extensions/shortcut_extension.dart
@@ -20,4 +20,7 @@ class ShortcutExtension extends DeviceExtension {
             onTap: () async {
               await createShortcut(macAddress, getDeviceNickname());
             });
+
+  @override
+  String get extensionName => "ShortcutExtension";
 }

--- a/lighthouse_provider/lighthouse_provider/lib/device_extensions/sleep_extension.dart
+++ b/lighthouse_provider/lighthouse_provider/lib/device_extensions/sleep_extension.dart
@@ -6,4 +6,7 @@ part of 'device_extension.dart';
 class SleepExtension extends StateExtension {
   SleepExtension({required super.changeState, required super.powerStateStream})
       : super(toolTip: "Sleep", toState: LighthousePowerState.sleep);
+
+  @override
+  String get extensionName => "SleepExtension";
 }

--- a/lighthouse_provider/lighthouse_provider/lib/src/devices/lighthouse_device.dart
+++ b/lighthouse_provider/lighthouse_provider/lib/src/devices/lighthouse_device.dart
@@ -7,6 +7,11 @@ abstract class LighthouseDevice {
   String get name;
 
   ///
+  /// The type of the device.
+  ///
+  String get deviceType;
+
+  ///
   /// The nickname of the device. This should be updated anytime the user
   /// changes it.
   ///

--- a/lighthouse_provider/lighthouse_provider/lib/src/devices/lighthouse_device.dart
+++ b/lighthouse_provider/lighthouse_provider/lib/src/devices/lighthouse_device.dart
@@ -100,11 +100,13 @@ abstract class LighthouseDevice {
   Future<void> changeState<C>(final LighthousePowerState newState,
       [final C? context]) async {
     if (newState == LighthousePowerState.unknown) {
-      lighthouseLogger.warning("Cannot set power state to unknown");
+      lighthouseLogger.warning("$name ($deviceIdentifier): "
+          "Cannot set power state to unknown");
       return;
     }
     if (newState == LighthousePowerState.booting) {
-      lighthouseLogger.warning("Cannot set power state to booting");
+      lighthouseLogger.warning("$name ($deviceIdentifier): "
+          "Cannot set power state to booting");
       return;
     }
     final request = await requestExtraInfo(context);
@@ -113,7 +115,8 @@ abstract class LighthouseDevice {
       await transactionMutex.protect(
           () => internalChangeState(newState), stack);
     } else {
-      lighthouseLogger.warning("Could not change state because the needed "
+      lighthouseLogger.warning("$name ($deviceIdentifier): "
+          "Could not change state because the needed "
           "extra info hasn't been provided");
     }
   }

--- a/lighthouse_provider/lighthouse_provider/lib/src/provider/provider.dart
+++ b/lighthouse_provider/lighthouse_provider/lib/src/provider/provider.dart
@@ -354,6 +354,13 @@ class LighthouseProvider {
         await _lighthouseDeviceMutex.acquire();
         final List<TimeoutContainer<LighthouseDevice>> list =
             _lightHouseDevices.valueOrNull ?? [];
+
+        // TODO: only return one lighthouse for testing. Remove this later
+        if (list.isNotEmpty) {
+          newDevice.disconnect();
+          return;
+        }
+
         // Check if this device is already in the list, which should never happen.
         if (list.cast<TimeoutContainer<LighthouseDevice>?>().firstWhere(
                 (final element) {
@@ -363,8 +370,9 @@ class LighthouseProvider {
               return false;
             }, orElse: () => null) !=
             null) {
-          lighthouseLogger.info("Found a device that has already been found! "
-              "Device id: ${newDevice.deviceIdentifier}, name: ${newDevice.name}");
+          lighthouseLogger
+              .info("${newDevice.name} (${newDevice.deviceIdentifier}): "
+                  "Found a device that has already been found!");
           return;
         }
 

--- a/lighthouse_provider/lighthouse_provider/test/device_extensions/device_extension_test.dart
+++ b/lighthouse_provider/lighthouse_provider/test/device_extensions/device_extension_test.dart
@@ -9,6 +9,9 @@ import 'package:test/test.dart';
 class DefaultEnabledDeviceExtension extends DeviceExtension {
   DefaultEnabledDeviceExtension()
       : super(toolTip: 'Default enabled', onTap: () async {});
+
+  @override
+  String get extensionName => "DefaultEnabledTestExtension";
 }
 
 void main() {

--- a/lighthouse_provider/lighthouse_provider/test/device_extensions/state_extension_test.dart
+++ b/lighthouse_provider/lighthouse_provider/test/device_extensions/state_extension_test.dart
@@ -18,6 +18,9 @@ class TestBootingStateExtension extends StateExtension {
             changeState: (final newState) async {},
             powerStateStream: () => Stream.value(LighthousePowerState.on),
             toState: LighthousePowerState.booting);
+
+  @override
+  String get extensionName => "TestBootingStateExtension";
 }
 
 ///
@@ -30,6 +33,9 @@ class TestUnknownStateExtension extends StateExtension {
             changeState: (final newState) async {},
             powerStateStream: () => Stream.value(LighthousePowerState.on),
             toState: LighthousePowerState.unknown);
+
+  @override
+  String get extensionName => "TestUnknownStateExtension";
 }
 
 void main() {

--- a/lighthouse_provider/lighthouse_provider/test/lighthouse_back_ends/fake/fake_pair_back_end.dart
+++ b/lighthouse_provider/lighthouse_provider/test/lighthouse_back_ends/fake/fake_pair_back_end.dart
@@ -57,4 +57,7 @@ class FakePairBackEnd extends BLELighthouseBackEnd with PairBackEnd {
     // TODO: implement pairNewDevice
     throw UnimplementedError();
   }
+
+  @override
+  String get backendName => 'Fake back end';
 }

--- a/lighthouse_provider/lighthouse_providers/lib/lighthouse_v2_device_provider.dart
+++ b/lighthouse_provider/lighthouse_providers/lib/lighthouse_v2_device_provider.dart
@@ -82,4 +82,7 @@ class LighthouseV2DeviceProvider
 
   @override
   String get namePrefix => "LHB-";
+
+  @override
+  String get providerName => "LighthouseV2DeviceProvider";
 }

--- a/lighthouse_provider/lighthouse_providers/lib/src/lighthouse_v2/device/lighthouse_v2_device.dart
+++ b/lighthouse_provider/lighthouse_providers/lib/src/lighthouse_v2/device/lighthouse_v2_device.dart
@@ -203,7 +203,6 @@ class LighthouseV2Device extends BLEDevice<LighthouseV2Persistence>
       });
       return true;
     }());
-
   }
 
   @override

--- a/lighthouse_provider/lighthouse_providers/lib/src/lighthouse_v2/device/lighthouse_v2_device.dart
+++ b/lighthouse_provider/lighthouse_providers/lib/src/lighthouse_v2/device/lighthouse_v2_device.dart
@@ -191,6 +191,9 @@ class LighthouseV2Device extends BLEDevice<LighthouseV2Persistence>
   String get name => device.name;
 
   @override
+  String get deviceType => "Lighthouse v2";
+
+  @override
   Future cleanupConnection() async {
     await _identifyDeviceExtension.close();
     _characteristic = null;

--- a/lighthouse_provider/lighthouse_providers/lib/src/lighthouse_v2/specific_extensions/identify_device_extension.dart
+++ b/lighthouse_provider/lighthouse_providers/lib/src/lighthouse_v2/specific_extensions/identify_device_extension.dart
@@ -27,4 +27,7 @@ class IdentifyDeviceExtension extends DeviceExtension {
       _enabledSubject = null;
     }
   }
+
+  @override
+  String get extensionName => "IdentifyExtension";
 }

--- a/lighthouse_provider/lighthouse_providers/lib/src/lighthouse_v2/specific_extensions/standby_extension.dart
+++ b/lighthouse_provider/lighthouse_providers/lib/src/lighthouse_v2/specific_extensions/standby_extension.dart
@@ -7,6 +7,9 @@ class StandbyExtension extends StateExtension {
   StandbyExtension(
       {required super.changeState, required super.powerStateStream})
       : super(toolTip: "Standby", toState: LighthousePowerState.standby);
+
+  @override
+  String get extensionName => "StandbyExtension";
 }
 
 extension StandbyExtensionExtensions on LighthouseDevice {

--- a/lighthouse_provider/lighthouse_providers/lib/src/vive_base_station/device/vive_base_station_device.dart
+++ b/lighthouse_provider/lighthouse_providers/lib/src/vive_base_station/device/vive_base_station_device.dart
@@ -103,30 +103,41 @@ class ViveBaseStationDevice extends BLEDevice<ViveBaseStationPersistence>
       pairIdEndHint = int.parse(name.substring(subStringLocation), radix: 16);
     } on FormatException catch (e, s) {
       lighthouseLogger.warning(
-          "Could not get device id end from name \"$name\"", e, s);
+          "${device.name} ($deviceIdentifier): "
+          "Could not get device id end",
+          e,
+          s);
     }
     if (persistence == null) {
-      lighthouseLogger.warning("Persistence not set for ViveBaseStationDevice, "
+      lighthouseLogger.warning("${device.name} ($deviceIdentifier): "
+          "Persistence not set for ViveBaseStationDevice, "
           "will not be able to store the id");
     }
     pairId = await persistence?.getId(deviceIdentifier);
     if (pairId == null) {
-      lighthouseLogger.warning("Pair di is not set yet for \"$name\"");
+      lighthouseLogger.warning("${device.name} ($deviceIdentifier): "
+          "Pair id is not set yet");
     }
-    lighthouseLogger.info("Connecting to device: $deviceIdentifier");
+    lighthouseLogger
+        .info("${device.name} ($deviceIdentifier): Connecting to device");
     try {
       await device.connect(timeout: Duration(seconds: 10));
     } on TimeoutException catch (e, s) {
       lighthouseLogger.warning(
-          "Connection timed-out for device: $deviceIdentifier", e, s);
+          "${device.name} ($deviceIdentifier): "
+          "Connection timed-out",
+          e,
+          s);
       return false;
     } catch (e, s) {
       // other connection error
-      lighthouseLogger.severe("Unknown connection error", e, s);
+      lighthouseLogger.severe(
+          "${device.name} ($deviceIdentifier): Unknown connection error", e, s);
       return false;
     }
 
-    lighthouseLogger.info("Finding services for device: $deviceIdentifier");
+    lighthouseLogger
+        .info("${device.name} ($deviceIdentifier):  Finding services");
     final List<LHBluetoothService> services = await device.discoverServices();
 
     final powerCharacteristic =
@@ -148,7 +159,10 @@ class ViveBaseStationDevice extends BLEDevice<ViveBaseStationPersistence>
             _firmwareVersion =
                 firmwareVersion.replaceAll('\r', '').replaceAll('\n', ' ');
           } catch (e, s) {
-            lighthouseLogger.severe("Unable to get firmware version", e, s);
+            lighthouseLogger.severe(
+                "${device.name} ($deviceIdentifier): Unable to get firmware version",
+                e,
+                s);
           }
           continue;
         }
@@ -199,7 +213,7 @@ class ViveBaseStationDevice extends BLEDevice<ViveBaseStationPersistence>
     if (callback == null) {
       assert(() {
         throw StateError(
-            "Request pair id has not been set on the vive provider");
+            "${device.name} ($deviceIdentifier):  Request pair id has not been set on the vive provider");
       }());
       return false;
     }
@@ -218,13 +232,15 @@ class ViveBaseStationDevice extends BLEDevice<ViveBaseStationPersistence>
         if (storage != null) {
           await storage.insertId(deviceIdentifier, pairId!);
         } else {
-          lighthouseLogger
-              .warning("Could not save device id because the storage was null");
+          lighthouseLogger.warning(
+              "${device.name} ($deviceIdentifier): Could not save device id because the storage was null");
         }
         return true;
       } on FormatException catch (e, s) {
         lighthouseLogger.warning(
-            "Could not convert device id to a number", e, s);
+            "${device.name} ($deviceIdentifier): Could not convert device id to a number",
+            e,
+            s);
       }
     }
     return false;

--- a/lighthouse_provider/lighthouse_providers/lib/src/vive_base_station/device/vive_base_station_device.dart
+++ b/lighthouse_provider/lighthouse_providers/lib/src/vive_base_station/device/vive_base_station_device.dart
@@ -46,6 +46,9 @@ class ViveBaseStationDevice extends BLEDevice<ViveBaseStationPersistence>
   String get name => device.name;
 
   @override
+  String get deviceType => "Vive base station";
+
+  @override
   Map<String, String?> get otherMetadata => _otherMetadata;
 
   @override

--- a/lighthouse_provider/lighthouse_providers/lib/src/vive_base_station/specific_extensions/clear_id_extension.dart
+++ b/lighthouse_provider/lighthouse_providers/lib/src/vive_base_station/specific_extensions/clear_id_extension.dart
@@ -18,4 +18,7 @@ class ClearIdExtension extends DeviceExtension {
       return persistence.hasIdStored(deviceId);
     };
   }
+
+  @override
+  String get extensionName => "ClearIdExtension";
 }

--- a/lighthouse_provider/lighthouse_providers/lib/vive_base_station_device_provider.dart
+++ b/lighthouse_provider/lighthouse_providers/lib/vive_base_station_device_provider.dart
@@ -94,4 +94,7 @@ class ViveBaseStationDeviceProvider
 
   @override
   String get namePrefix => "HTC BS";
+
+  @override
+  String get providerName => "ViveBaseStationDeviceProvider";
 }

--- a/lighthouse_provider/lighthouse_test_helper/lib/src/fake_ble_device_provider.dart
+++ b/lighthouse_provider/lighthouse_test_helper/lib/src/fake_ble_device_provider.dart
@@ -14,6 +14,9 @@ class FakeBLEDeviceProvider extends BLEDeviceProvider {
   @override
   String get namePrefix => "LHB-";
 
+  @override
+  String get providerName => '';
+
   /// Not needed
   @override
   List<LighthouseGuid> get characteristics => throw UnimplementedError();

--- a/lighthouse_provider/lighthouse_test_helper/lib/src/fake_high_level_device.dart
+++ b/lighthouse_provider/lighthouse_test_helper/lib/src/fake_high_level_device.dart
@@ -67,6 +67,9 @@ class FakeHighLevelDevice extends BLEDevice implements DeviceWithExtensions {
   String get name => device.name;
 
   @override
+  String get deviceType => "Fake high level device";
+
+  @override
   Map<String, String?> get otherMetadata => throw UnimplementedError();
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -476,6 +476,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lighthouse_back_end:
     dependency: "direct main"
     description:
@@ -539,26 +563,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -619,10 +643,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_parsing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.3.1+12
+version: 1.3.2-beta1+13
 
 environment:
   sdk: ">=2.19.0 <3.0.0"

--- a/scripts/build-release-apks-github.sh
+++ b/scripts/build-release-apks-github.sh
@@ -6,7 +6,9 @@ cd "$SCRIPT_DIR/../" || exit
 
 patch -p1 -d "${SCRIPT_DIR}/../" <"${SCRIPT_DIR}/split-per-abi-build.gradle.patch"
 
-flutter build apk --release --no-obfuscate \
+BUILD_FLAVOR="release"
+
+flutter build apk --"$BUILD_FLAVOR" --no-obfuscate \
   --flavor=defaultVersion \
   --dart-define=includeGooglePlayInAppPurchases=false \
   --dart-define=includeSupportButtons=true \
@@ -35,7 +37,7 @@ function copy_result() {
   VERSION=$1
   ABI=$2
   NEW_ABI=$3
-  ORIGINAL_PATH="${SCRIPT_DIR}/../build/app/outputs/flutter-apk/app-${ABI}-defaultversion-release.apk"
+  ORIGINAL_PATH="${SCRIPT_DIR}/../build/app/outputs/flutter-apk/app-${ABI}-defaultversion-$BUILD_FLAVOR.apk"
   NEW_PATH="${SCRIPT_DIR}/../output/lighthouse_pm-${VERSION}.${NEW_ABI}.apk"
   cp -vrf "$ORIGINAL_PATH" "$NEW_PATH"
 }

--- a/test/lighthouse_provider/widgets/unknown_state_alert_widget_test.dart
+++ b/test/lighthouse_provider/widgets/unknown_state_alert_widget_test.dart
@@ -299,7 +299,7 @@ void main() {
         .toPlainText();
 
     expect(text, contains("fake-version"));
-    expect(text, contains("FakeHighLevelDevice"));
+    expect(text, contains("Fake high level device"));
 
     await tester.tap(find.text('Cancel'));
     await tester.pumpAndSettle();
@@ -336,7 +336,7 @@ void main() {
         .toPlainText();
 
     expect(text, contains("fake-version"));
-    expect(text, contains("FakeHighLevelDevice"));
+    expect(text, contains("Fake high level device"));
 
     await tester.tap(find.text('Open issue'));
     await tester.pumpAndSettle();
@@ -375,7 +375,7 @@ void main() {
     final text = textWidget.text.toPlainText();
 
     expect(text, contains("fake-version"));
-    expect(text, contains("FakeHighLevelDevice"));
+    expect(text, contains("Fake high level device"));
 
     final held = holdTextSpan(textWidget, "App version: ");
     expect(held, isTrue);

--- a/test/lighthouse_provider/widgets/widget_for_extension_test.dart
+++ b/test/lighthouse_provider/widgets/widget_for_extension_test.dart
@@ -12,6 +12,9 @@ import 'package:lighthouse_test_helper/lighthouse_test_helper.dart';
 class DefaultEnabledDeviceExtension extends DeviceExtension {
   DefaultEnabledDeviceExtension()
       : super(toolTip: 'Default enabled', onTap: () async {});
+
+  @override
+  String get extensionName => "DefaultEnabledExtension";
 }
 
 void main() {


### PR DESCRIPTION
## Keep the old device list when resuming the app.

This stops the devices from leaving when you open and close the notification panel

Stop using `runtimeType` since they are compiled away (at least for web builds)

## Created log page for debugging

## Added debug option for release builds

lighthouse provider: Providers can now be added before back ends

Tapping the version number in settings 10 times enables debug mode.

Enabling debug mode enables:
 - Adding a fake back end
 - Looking at the logs
 - Looking at the material test page